### PR TITLE
Remove the health check clienter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,19 +36,20 @@ var BuildTime, GitCommit, Version string
 func main() {
     ...
 
+    criticalTimeout := time.Minute
+    interval := 10 * time.Second
+
     versionInfo := health.CreateVersionInfo(
         time.Unix(BuildTime, 0),
         GitCommit,
         Version,
     )
 
-    var clients []*health.Client
-    clients := append(clients, <newClient>)
+    # Initialise your clients
+    cli1 := client1.NewAPIClient()
+    cli2 := client2.NewDataStoreClient()
 
-    criticalTimeout := time.Minute
-    interval := 10 * time.Second
-
-    hc := health.Create(versionInfo criticalTimeout, interval, clients)
+    hc := health.Create(versionInfo criticalTimeout, interval, &cli1.Checker, &cli2.Checker)
 
     ...
 }
@@ -60,7 +61,7 @@ func main() {
     ...
     mongoClient := <mongo health client>
 
-    if err = hc.AddClient(mongoClient); err != nil {
+    if err = hc.AddCheck(&mongoClient.Checker); err != nil {
         ...
     }
     ...

--- a/healthcheck/client.go
+++ b/healthcheck/client.go
@@ -3,29 +3,25 @@ package healthcheck
 import (
 	"errors"
 	"sync"
-
-	rchttp "github.com/ONSdigital/dp-rchttp"
 )
 
-// Client represents a healthcheck client
+// Client represents a health check client
 type Client struct {
-	Clienter rchttp.Clienter
-	Check    *Check
-	Checker  *Checker
-	mutex    *sync.Mutex
+	Check   *Check
+	Checker *Checker
+	mutex   *sync.Mutex
 }
 
-// NewClient returns a pointer to a new instantiated Client with
+// newClient returns a pointer to a new instantiated Client with
 // the provided checker function and an rchttp.Clienter
-func NewClient(cli rchttp.Clienter, checker *Checker) (*Client, error) {
-	if cli == nil {
-		return nil, errors.New("expected clienter but none provided")
+func newClient(checker *Checker) (*Client, error) {
+	if checker == nil {
+		return nil, errors.New("expected checker but none provided")
 	}
 
 	return &Client{
-		Clienter: cli,
-		Check:    nil,
-		Checker:  checker,
-		mutex:    &sync.Mutex{},
+		Check:   nil,
+		Checker: checker,
+		mutex:   &sync.Mutex{},
 	}, nil
 }

--- a/healthcheck/client_test.go
+++ b/healthcheck/client_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	rchttp "github.com/ONSdigital/dp-rchttp"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -13,26 +12,24 @@ func TestCreateNew(t *testing.T) {
 		checkerFunc = Checker(func(ctx context.Context) (check *Check, err error) {
 			return
 		})
-		cli      *Client
-		err      error
-		clienter = rchttp.NewClient()
+		cli *Client
+		err error
 	)
 	Convey("Create a new Client", t, func() {
-		cli, err = NewClient(clienter, &checkerFunc)
+		cli, _ = newClient(&checkerFunc)
 		So(err, ShouldBeNil)
 		So(cli.Checker, ShouldPointTo, &checkerFunc)
 		So(cli.mutex, ShouldNotBeNil)
-		So(cli.Clienter, ShouldNotBeNil)
 		So(cli.Check, ShouldBeNil)
 	})
 	Convey("A second new client shares the right values", t, func() {
-		cli2, err := NewClient(clienter, &checkerFunc)
+		cli2, err := newClient(&checkerFunc)
 		So(err, ShouldBeNil)
 		So(cli2.Checker, ShouldPointTo, cli.Checker)
 		So(cli2.mutex, ShouldNotPointTo, cli.mutex)
 	})
-	Convey("Fail to create a new client as clienter given is nil", t, func() {
-		cli3, err := NewClient(nil, &checkerFunc)
+	Convey("Fail to create a new client as checker given is nil", t, func() {
+		cli3, err := newClient(nil)
 		So(cli3, ShouldBeNil)
 		So(err, ShouldNotBeNil)
 	})

--- a/healthcheck/handler_test.go
+++ b/healthcheck/handler_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	rchttp "github.com/ONSdigital/dp-rchttp"
 	"github.com/ONSdigital/log.go/log"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -31,8 +30,7 @@ func createATestChecker(checkToReturn Check) *Checker {
 
 func createATestClient(checkToReturn Check, pretendHistory bool) *Client {
 	checkerFunc := createATestChecker(checkToReturn)
-	clienter := rchttp.NewClient()
-	cli, _ := NewClient(clienter, checkerFunc)
+	cli, _ := newClient(checkerFunc)
 	if pretendHistory {
 		cli.Check = &checkToReturn
 	}


### PR DESCRIPTION
### What

The clienter was not actually being used but was adding additional dev
overhead in needing to create a health check client for each check and
pass it in.  Removal of the clienter allows us to simplify the usage of this
library.

### Who can review

Anyone but me.