### PR TITLE
Polish usage: Remove need to cast Checkers, parse build time, store check state and work out state updates

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2019 Office for National Statistics (https://www.ons.gov.uk)
+Copyright (c) 2019-2020 Office for National Statistics (https://www.ons.gov.uk)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Adding a health check to an app
     ```
         ...
 
-        hc, err := health.Create(versionInfo criticalTimeout, interval, CheckFunc1, CheckFunc2, someClient.Check)
+        hc, err := health.New(versionInfo criticalTimeout, interval, CheckFunc1, CheckFunc2, someClient.Check)
         if err != nil {
             ...
         }
@@ -83,7 +83,7 @@ Adding a health check to an app
     ```
         ...
 
-        hc, err := health.Create(versionInfo criticalTimeout, interval)
+        hc, err := health.New(versionInfo criticalTimeout, interval)
         if err != nil {
             ...
         }

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Adding a health check to an app
 
         ...
 
+        // Likely these values would come from your app's config
+        criticalTimeout := time.Minute
+        interval := 10 * time.Second
+
+        ...
+
         versionInfo := health.CreateVersionInfo(
             BuildTime,
             GitCommit,
@@ -212,35 +218,25 @@ Implement a checker by creating a function (with or without a receiver) that is 
 For example:
 
 ```
+
+const checkName = "check name"
+
 func Check(ctx context.Context, state *CheckState) error {
-	now := time.Now()
-
-	if state.Name == "" {
-		state.Name = "check name"
-	}
-
 	success := rand.Float32() < 0.5
 	warn := rand.Float32() < 0.5
 
 	if success {
-		state.Status = health.StatusOK
-		state.Message = "I'm OK"
-		state.LastSuccess = &now
+        state.Update(checkName, health.StatusOK, "I'm OK", 200)
 	} else if warn {
-		state.Status = health.StatusWarning
-		state.Message = "degraded function of ..."
-		state.LastFailure = &now
+        state.Update(checkName, health.StatusWarning, "degraded function of ...", 0)
 	} else {
-		state.Status = health.StatusCritical
-		state.Message = "failed to ..."
-		state.LastFailure = &now
+        state.Update(checkName, health.StatusWarning, "failed to ...", 503)
 	}
-	state.LastChecked = &now
 	return nil
 }
 ```
 
-Note that the `StatusCode` field is optional and only used for HTTP based checks.
+Note that the `statusCode` argument (last argument) to `CheckState.Update()` is only used for HTTP based checks.  If you do not have a status code then pass `0` as seen in the example above (degraded state/warning block).
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -32,16 +32,22 @@ Adding a health check to an app
     ...
 
     var BuildTime, GitCommit, Version string
-    const criticalTimeout = time.Minute
-    const interval = 10 * time.Second
+
     ...
 
     func main() {
         ctx := context.Context(context.Background())
+
+        ...
+
+        // Likely these values would come from your app's config
+        criticalTimeout := time.Minute
+        interval := 10 * time.Second
+
         ...
 
         versionInfo := health.CreateVersionInfo(
-            time.Unix(BuildTime, 0),
+            BuildTime,
             GitCommit,
             Version,
         )

--- a/healthcheck/check.go
+++ b/healthcheck/check.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"sync"
 	"time"
+	"fmt"
 )
 
 // A list of possible check statuses
@@ -20,6 +21,18 @@ type Checker func(context.Context, *CheckState) error
 
 // CheckState represents the health status returned by a checker
 type CheckState struct {
+	name        string
+	status      string
+	statusCode  int
+	message     string
+	lastChecked *time.Time
+	lastSuccess *time.Time
+	lastFailure *time.Time
+	mutex       *sync.RWMutex
+}
+
+// checkStateJSON represents the health status struct for use with json marshal/unmarshal (to deal with unexported fields)
+type checkStateJSON struct {
 	Name        string     `json:"name"`
 	Status      string     `json:"status"`
 	StatusCode  int        `json:"status_code,omitempty"`
@@ -33,15 +46,114 @@ type CheckState struct {
 type Check struct {
 	state   *CheckState
 	checker Checker
-	mutex   *sync.Mutex
+}
+
+// Name gets the check name
+func (s *CheckState) Name() string {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	return s.name
+}
+
+// Status gets the check status
+func (s *CheckState) Status() string {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	return s.status
+}
+
+// StatusCode gets the check status code
+func (s *CheckState) StatusCode() int {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	return s.statusCode
+}
+
+// Message gets the check message
+func (s *CheckState) Message() string {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	return s.message
+}
+
+// LastChecked gets the last checked time of the check
+func (s *CheckState) LastChecked() *time.Time {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	if s.lastChecked == nil {
+		return nil
+	}
+
+	t := *s.lastChecked
+	return &t
+}
+
+// LastSuccess gets the time of the last successful check
+func (s *CheckState) LastSuccess() *time.Time {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	if s.lastSuccess == nil {
+		return nil
+	}
+
+	t := *s.lastSuccess
+	return &t
+}
+
+// LastFailure gets the time of the last failed check
+func (s *CheckState) LastFailure() *time.Time {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	if s.lastFailure == nil {
+		return nil
+	}
+
+	t := *s.lastFailure
+	return &t
+}
+
+// Update updates the relavent state fields based on the status provided
+// name of the check
+// status of the check, must be one of healthcheck.StatusOK, healthcheck.StatusWarning or healthcheck.StatusCritical
+// message briefly describing the check state
+// statusCode returned if the check was an HTTP check (optional, provide 0 if not relevant)
+func (s *CheckState) Update(name, status, message string, statusCode int) error {
+	now := time.Now().UTC()
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	switch status {
+	case StatusOK:
+		s.lastSuccess = &now
+	case StatusWarning, StatusCritical:
+		s.lastFailure = &now
+	default:
+		return fmt.Errorf("invalid check status, must be one of %s, %s or %s", StatusOK, StatusWarning, StatusCritical)
+	}
+
+	s.status = status
+	s.message = message
+	s.statusCode = statusCode
+	s.lastChecked = &now
+
+	if s.name == "" {
+		s.name = name
+	}
+
+	return nil
 }
 
 // hasRun returns true if the check has been run and has state
 func (c *Check) hasRun() bool {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	if c.state.LastChecked == nil {
+	if c.state.LastChecked() == nil {
 		return false
 	}
 	return true
@@ -55,26 +167,55 @@ func newCheck(checker Checker) (*Check, error) {
 	}
 
 	return &Check{
-		state:   &CheckState{},
+		state: &CheckState{
+			mutex: &sync.RWMutex{},
+		},
 		checker: checker,
-		mutex:   &sync.Mutex{},
 	}, nil
 }
 
 func (c *Check) MarshalJSON() ([]byte, error) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
+	return json.Marshal(c.state)
+}
 
-	b, err := json.Marshal(c.state)
-	if err != nil {
-		return nil, err
-	}
-	return b, nil
+func (s *CheckState) MarshalJSON() ([]byte, error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	return json.Marshal(checkStateJSON{
+		Name:        s.name,
+		Status:      s.status,
+		StatusCode:  s.statusCode,
+		Message:     s.message,
+		LastChecked: s.lastChecked,
+		LastSuccess: s.lastSuccess,
+		LastFailure: s.lastFailure,
+	})
 }
 
 func (c *Check) UnmarshalJSON(b []byte) error {
-	if err := json.Unmarshal(b, &c.state); err != nil {
-		return err
+	if c.state == nil {
+		c.state = &CheckState{
+			mutex: &sync.RWMutex{},
+		}
 	}
-	return nil
+	return json.Unmarshal(b, c.state)
+}
+
+func (s *CheckState) UnmarshalJSON(b []byte) error {
+	temp := &checkStateJSON{}
+	err := json.Unmarshal(b, temp)
+	if err == nil {
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
+
+		s.name = temp.Name
+		s.status = temp.Status
+		s.statusCode = temp.StatusCode
+		s.message = temp.Message
+		s.lastChecked = temp.LastChecked
+		s.lastSuccess = temp.LastSuccess
+		s.lastFailure = temp.LastFailure
+	}
+	return err
 }

--- a/healthcheck/check.go
+++ b/healthcheck/check.go
@@ -8,8 +8,15 @@ import (
 	"time"
 )
 
+// A list of possible check statuses
+const (
+	StatusOK       = "OK"
+	StatusWarning  = "WARNING"
+	StatusCritical = "CRITICAL"
+)
+
 // Checker represents the interface all checker functions abide to
-type Checker func(context.Context) (*CheckState, error)
+type Checker func(context.Context, *CheckState) error
 
 // CheckState represents the health status returned by a checker
 type CheckState struct {
@@ -24,9 +31,20 @@ type CheckState struct {
 
 // Check represents a check performed by the health check
 type Check struct {
-	State   *CheckState
-	Checker Checker
+	state   *CheckState
+	checker Checker
 	mutex   *sync.Mutex
+}
+
+// hasRun returns true if the check has been run and has state
+func (c *Check) hasRun() bool {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if c.state.LastChecked == nil {
+		return false
+	}
+	return true
 }
 
 // newCheck returns a pointer to a new instantiated Check with
@@ -37,14 +55,17 @@ func newCheck(checker Checker) (*Check, error) {
 	}
 
 	return &Check{
-		State:   nil,
-		Checker: checker,
+		state:   &CheckState{},
+		checker: checker,
 		mutex:   &sync.Mutex{},
 	}, nil
 }
 
 func (c *Check) MarshalJSON() ([]byte, error) {
-	b, err := json.Marshal(c.State)
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	b, err := json.Marshal(c.state)
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +73,7 @@ func (c *Check) MarshalJSON() ([]byte, error) {
 }
 
 func (c *Check) UnmarshalJSON(b []byte) error {
-	if err := json.Unmarshal(b, &c.State); err != nil {
+	if err := json.Unmarshal(b, &c.state); err != nil {
 		return err
 	}
 	return nil

--- a/healthcheck/check.go
+++ b/healthcheck/check.go
@@ -25,13 +25,13 @@ type CheckState struct {
 // Check represents a check performed by the health check
 type Check struct {
 	State   *CheckState
-	Checker *Checker
+	Checker Checker
 	mutex   *sync.Mutex
 }
 
 // newCheck returns a pointer to a new instantiated Check with
 // the provided checker function
-func newCheck(checker *Checker) (*Check, error) {
+func newCheck(checker Checker) (*Check, error) {
 	if checker == nil {
 		return nil, errors.New("expected checker but none provided")
 	}

--- a/healthcheck/check_test.go
+++ b/healthcheck/check_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestCreateNew(t *testing.T) {
 	var (
-		checkerFunc = func(ctx context.Context) (check *CheckState, err error) {
-			return &CheckState{}, nil
+		checkerFunc = func(ctx context.Context, check *CheckState) error {
+			return nil
 		}
 		check *Check
 		err   error
@@ -18,14 +18,14 @@ func TestCreateNew(t *testing.T) {
 	Convey("Create a new check", t, func() {
 		check, _ = newCheck(checkerFunc)
 		So(err, ShouldBeNil)
-		So(check.Checker, ShouldEqual, checkerFunc)
+		So(check.checker, ShouldEqual, checkerFunc)
 		So(check.mutex, ShouldNotBeNil)
-		So(check.State, ShouldBeNil)
+		So(check.state, ShouldResemble, &CheckState{})
 	})
 	Convey("A second new check shares the right values", t, func() {
 		check2, err := newCheck(checkerFunc)
 		So(err, ShouldBeNil)
-		So(check2.Checker, ShouldEqual, check.Checker)
+		So(check2.checker, ShouldEqual, check.checker)
 		So(check2.mutex, ShouldNotPointTo, check.mutex)
 	})
 	Convey("Fail to create a new check as checker given is nil", t, func() {
@@ -33,5 +33,4 @@ func TestCreateNew(t *testing.T) {
 		So(check3, ShouldBeNil)
 		So(err, ShouldNotBeNil)
 	})
-
 }

--- a/healthcheck/check_test.go
+++ b/healthcheck/check_test.go
@@ -19,7 +19,7 @@ func TestCreateNew(t *testing.T) {
 		err   error
 	)
 	Convey("Create a new check", t, func() {
-		check, _ = newCheck(checkerFunc)
+		check, _ = NewCheck(checkerFunc)
 		So(err, ShouldBeNil)
 		So(check.checker, ShouldEqual, checkerFunc)
 		So(check.state.mutex, ShouldNotBeNil)
@@ -32,13 +32,13 @@ func TestCreateNew(t *testing.T) {
 		So(check.state.lastFailure, ShouldBeNil)
 	})
 	Convey("A second new check shares the right values", t, func() {
-		check2, err := newCheck(checkerFunc)
+		check2, err := NewCheck(checkerFunc)
 		So(err, ShouldBeNil)
 		So(check2.checker, ShouldEqual, check.checker)
 		So(check2.state.mutex, ShouldNotPointTo, check.state.mutex)
 	})
 	Convey("Fail to create a new check as checker given is nil", t, func() {
-		check3, err := newCheck(nil)
+		check3, err := NewCheck(nil)
 		So(check3, ShouldBeNil)
 		So(err, ShouldNotBeNil)
 	})
@@ -205,7 +205,7 @@ func TestGets(t *testing.T) {
 			lastChecked: &t0,
 			lastSuccess: &t1,
 			lastFailure: &t2,
-			mutex: &sync.RWMutex{},
+			mutex:       &sync.RWMutex{},
 		}
 
 		Convey("When getting the name", func() {
@@ -302,7 +302,7 @@ func TestJSONMarshalling(t *testing.T) {
 		checkerFunc := func(ctx context.Context, state *CheckState) error {
 			return nil
 		}
-		check, err := newCheck(checkerFunc)
+		check, err := NewCheck(checkerFunc)
 		check.state.name = "something"
 		check.state.status = "OK"
 		check.state.message = "this is a message"
@@ -321,7 +321,7 @@ func TestJSONMarshalling(t *testing.T) {
 			})
 
 			Convey("When unmarshalling from json", func() {
-				check2, err := newCheck(checkerFunc)
+				check2, err := NewCheck(checkerFunc)
 
 				So(err, ShouldBeNil)
 

--- a/healthcheck/check_test.go
+++ b/healthcheck/check_test.go
@@ -2,7 +2,10 @@ package healthcheck
 
 import (
 	"context"
+	"encoding/json"
+	"sync"
 	"testing"
+	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -19,18 +22,320 @@ func TestCreateNew(t *testing.T) {
 		check, _ = newCheck(checkerFunc)
 		So(err, ShouldBeNil)
 		So(check.checker, ShouldEqual, checkerFunc)
-		So(check.mutex, ShouldNotBeNil)
-		So(check.state, ShouldResemble, &CheckState{})
+		So(check.state.mutex, ShouldNotBeNil)
+		So(check.state.name, ShouldEqual, "")
+		So(check.state.status, ShouldEqual, "")
+		So(check.state.statusCode, ShouldEqual, 0)
+		So(check.state.message, ShouldEqual, "")
+		So(check.state.lastChecked, ShouldBeNil)
+		So(check.state.lastSuccess, ShouldBeNil)
+		So(check.state.lastFailure, ShouldBeNil)
 	})
 	Convey("A second new check shares the right values", t, func() {
 		check2, err := newCheck(checkerFunc)
 		So(err, ShouldBeNil)
 		So(check2.checker, ShouldEqual, check.checker)
-		So(check2.mutex, ShouldNotPointTo, check.mutex)
+		So(check2.state.mutex, ShouldNotPointTo, check.state.mutex)
 	})
 	Convey("Fail to create a new check as checker given is nil", t, func() {
 		check3, err := newCheck(nil)
 		So(check3, ShouldBeNil)
 		So(err, ShouldNotBeNil)
+	})
+}
+
+func TestUpdate(t *testing.T) {
+	var (
+		checkName   = "check name"
+		okMessage   = "I'm OK"
+		failMessage = "failed to ..."
+	)
+
+	Convey("Given a new check state", t, func() {
+		before := time.Now().UTC()
+
+		state := &CheckState{
+			mutex: &sync.RWMutex{},
+		}
+
+		Convey("When the state is updated with OK status", func() {
+			err := state.Update(checkName, StatusOK, okMessage, 200)
+			So(err, ShouldBeNil)
+
+			Convey("Then the check state should be set accordingly", func() {
+				after := time.Now().UTC()
+
+				So(state.name, ShouldEqual, checkName)
+				So(state.status, ShouldEqual, StatusOK)
+				So(state.message, ShouldEqual, okMessage)
+				So(state.statusCode, ShouldEqual, 200)
+				So(*state.lastChecked, ShouldHappenOnOrBetween, before, after)
+				So(*state.lastSuccess, ShouldHappenOnOrBetween, before, after)
+			})
+		})
+	})
+
+	Convey("Given a new check state", t, func() {
+		before := time.Now().UTC()
+
+		state := &CheckState{
+			mutex: &sync.RWMutex{},
+		}
+
+		Convey("When the state is updated with warning status", func() {
+			err := state.Update(checkName, StatusWarning, failMessage, 200)
+			So(err, ShouldBeNil)
+
+			Convey("Then the check state should be set accordingly", func() {
+				after := time.Now().UTC()
+
+				So(state.name, ShouldEqual, checkName)
+				So(state.status, ShouldEqual, StatusWarning)
+				So(state.message, ShouldEqual, failMessage)
+				So(state.statusCode, ShouldEqual, 200)
+				So(*state.lastChecked, ShouldHappenOnOrBetween, before, after)
+				So(*state.lastFailure, ShouldHappenOnOrBetween, before, after)
+			})
+		})
+	})
+
+	Convey("Given a new check state with valid existing state", t, func() {
+		before := time.Now().UTC()
+
+		state := &CheckState{
+			mutex: &sync.RWMutex{},
+		}
+
+		Convey("When the state is updated with critical status", func() {
+			err := state.Update(checkName, StatusCritical, failMessage, 502)
+			So(err, ShouldBeNil)
+
+			Convey("Then the check state should be set accordingly", func() {
+				after := time.Now().UTC()
+
+				So(state.name, ShouldEqual, checkName)
+				So(state.status, ShouldEqual, StatusCritical)
+				So(state.message, ShouldEqual, failMessage)
+				So(state.statusCode, ShouldEqual, 502)
+				So(*state.lastChecked, ShouldHappenOnOrBetween, before, after)
+				So(*state.lastFailure, ShouldHappenOnOrBetween, before, after)
+			})
+		})
+	})
+
+	Convey("Given a new check state", t, func() {
+		before := time.Now().UTC()
+
+		state := &CheckState{
+			mutex: &sync.RWMutex{},
+		}
+		err := state.Update(checkName, StatusOK, okMessage, 200)
+		So(err, ShouldBeNil)
+
+		after := time.Now().UTC()
+
+		So(state.name, ShouldEqual, checkName)
+		So(state.status, ShouldEqual, StatusOK)
+		So(state.message, ShouldEqual, okMessage)
+		So(state.statusCode, ShouldEqual, 200)
+		So(*state.lastChecked, ShouldHappenOnOrBetween, before, after)
+		So(*state.lastSuccess, ShouldHappenOnOrBetween, before, after)
+
+		Convey("When the state is updated with another state", func() {
+			before2 := time.Now().UTC()
+			err := state.Update(checkName, StatusCritical, failMessage, 0)
+			So(err, ShouldBeNil)
+
+			Convey("Then then only the changed fields should overwitten", func() {
+				after2 := time.Now().UTC()
+
+				So(state.name, ShouldEqual, checkName)
+				So(state.status, ShouldEqual, StatusCritical)
+				So(state.message, ShouldEqual, failMessage)
+				So(state.statusCode, ShouldEqual, 0)
+				So(*state.lastChecked, ShouldHappenOnOrBetween, before2, after2)
+				So(*state.lastFailure, ShouldHappenOnOrBetween, before2, after2)
+				So(*state.lastSuccess, ShouldHappenOnOrBetween, before, after)
+			})
+		})
+	})
+
+	Convey("Given a new check state with valid existing state", t, func() {
+		state := &CheckState{
+			mutex: &sync.RWMutex{},
+		}
+
+		Convey("When the state is updated with an invalid status", func() {
+			err := state.Update(checkName, "some invalid status", failMessage, 502)
+
+			Convey("Then an error should be returned", func() {
+				So(err, ShouldNotBeNil)
+			})
+		})
+	})
+
+	Convey("Given a new check state with an existing name", t, func() {
+		state := &CheckState{
+			name:  checkName,
+			mutex: &sync.RWMutex{},
+		}
+		So(state.name, ShouldEqual, checkName)
+
+		Convey("When the state is updated", func() {
+			err := state.Update("a new name", StatusOK, okMessage, 0)
+			So(err, ShouldBeNil)
+
+			Convey("Then the name should not be changed", func() {
+				So(state.name, ShouldEqual, checkName)
+			})
+		})
+	})
+}
+
+func TestGets(t *testing.T) {
+	Convey("Given a populated check state", t, func() {
+		t0 := time.Unix(0, 0).UTC()
+		t1 := t0.Add(1 * time.Minute)
+		t2 := t0.Add(2 * time.Minute)
+		state := CheckState{
+			name:        "something",
+			status:      "OK",
+			message:     "this is a message",
+			statusCode:  200,
+			lastChecked: &t0,
+			lastSuccess: &t1,
+			lastFailure: &t2,
+			mutex: &sync.RWMutex{},
+		}
+
+		Convey("When getting the name", func() {
+			name := state.Name()
+
+			Convey("Then the correct name should be returned", func() {
+				So(name, ShouldEqual, state.name)
+			})
+		})
+
+		Convey("When getting the status", func() {
+			status := state.Status()
+
+			Convey("Then the correct status should be returned", func() {
+				So(status, ShouldEqual, state.status)
+			})
+		})
+
+		Convey("When getting the message", func() {
+			message := state.Message()
+
+			Convey("Then the correct message should be returned", func() {
+				So(message, ShouldEqual, state.message)
+			})
+		})
+
+		Convey("When getting the status code", func() {
+			statusCode := state.StatusCode()
+
+			Convey("Then the correct status code should be returned", func() {
+				So(statusCode, ShouldEqual, state.statusCode)
+			})
+		})
+
+		Convey("When getting the last checked time", func() {
+			lastChecked := state.LastChecked()
+
+			Convey("Then the correct time should be returned", func() {
+				So(lastChecked, ShouldResemble, state.lastChecked)
+			})
+		})
+
+		Convey("When getting the last success time", func() {
+			lastSuccess := state.LastSuccess()
+
+			Convey("Then the correct time should be returned", func() {
+				So(lastSuccess, ShouldResemble, state.lastSuccess)
+			})
+		})
+
+		Convey("When getting the last failure time", func() {
+			lastFailure := state.LastFailure()
+
+			Convey("Then the correct time should be returned", func() {
+				So(lastFailure, ShouldResemble, state.lastFailure)
+			})
+		})
+	})
+
+	Convey("Given an unpopulated check state", t, func() {
+		state := CheckState{
+			mutex: &sync.RWMutex{},
+		}
+
+		Convey("When getting the last checked time", func() {
+			lastChecked := state.LastChecked()
+
+			Convey("Then nil should be returned", func() {
+				So(lastChecked, ShouldBeNil)
+			})
+		})
+
+		Convey("When getting the last success time", func() {
+			lastSuccess := state.LastSuccess()
+
+			Convey("Then nil should be returned", func() {
+				So(lastSuccess, ShouldBeNil)
+			})
+		})
+
+		Convey("When getting the last failure time", func() {
+			lastFailure := state.LastFailure()
+
+			Convey("Then nil should be returned", func() {
+				So(lastFailure, ShouldBeNil)
+			})
+		})
+	})
+}
+
+func TestJSONMarshalling(t *testing.T) {
+	Convey("Given a new check with a populated state", t, func() {
+		t := time.Unix(0, 0).UTC()
+		checkerFunc := func(ctx context.Context, state *CheckState) error {
+			return nil
+		}
+		check, err := newCheck(checkerFunc)
+		check.state.name = "something"
+		check.state.status = "OK"
+		check.state.message = "this is a message"
+		check.state.statusCode = 200
+		check.state.lastChecked = &t
+		check.state.lastSuccess = &t
+		check.state.lastFailure = &t
+
+		So(err, ShouldBeNil)
+		Convey("When marshalling to json", func() {
+			j, err := json.Marshal(check)
+
+			Convey("Then the string form of the state should successful marshal", func() {
+				So(err, ShouldBeNil)
+				So(string(j), ShouldEqual, "{\"name\":\"something\",\"status\":\"OK\",\"status_code\":200,\"message\":\"this is a message\",\"last_checked\":\"1970-01-01T00:00:00Z\",\"last_success\":\"1970-01-01T00:00:00Z\",\"last_failure\":\"1970-01-01T00:00:00Z\"}")
+			})
+
+			Convey("When unmarshalling from json", func() {
+				check2, err := newCheck(checkerFunc)
+
+				So(err, ShouldBeNil)
+
+				err = json.Unmarshal(j, check2)
+
+				So(err, ShouldBeNil)
+				So(check2.state.name, ShouldEqual, check.state.name)
+				So(check2.state.status, ShouldEqual, check.state.status)
+				So(check2.state.statusCode, ShouldEqual, check.state.statusCode)
+				So(check2.state.message, ShouldEqual, check.state.message)
+				So(*check2.state.lastChecked, ShouldEqual, *check.state.lastChecked)
+				So(*check2.state.lastFailure, ShouldEqual, *check.state.lastFailure)
+				So(*check2.state.lastSuccess, ShouldEqual, *check.state.lastSuccess)
+			})
+		})
 	})
 }

--- a/healthcheck/check_test.go
+++ b/healthcheck/check_test.go
@@ -9,23 +9,23 @@ import (
 
 func TestCreateNew(t *testing.T) {
 	var (
-		checkerFunc = Checker(func(ctx context.Context) (check *CheckState, err error) {
+		checkerFunc = func(ctx context.Context) (check *CheckState, err error) {
 			return &CheckState{}, nil
-		})
+		}
 		check *Check
 		err   error
 	)
 	Convey("Create a new check", t, func() {
-		check, _ = newCheck(&checkerFunc)
+		check, _ = newCheck(checkerFunc)
 		So(err, ShouldBeNil)
-		So(check.Checker, ShouldPointTo, &checkerFunc)
+		So(check.Checker, ShouldEqual, checkerFunc)
 		So(check.mutex, ShouldNotBeNil)
 		So(check.State, ShouldBeNil)
 	})
 	Convey("A second new check shares the right values", t, func() {
-		check2, err := newCheck(&checkerFunc)
+		check2, err := newCheck(checkerFunc)
 		So(err, ShouldBeNil)
-		So(check2.Checker, ShouldPointTo, check.Checker)
+		So(check2.Checker, ShouldEqual, check.Checker)
 		So(check2.mutex, ShouldNotPointTo, check.mutex)
 	})
 	Convey("Fail to create a new check as checker given is nil", t, func() {

--- a/healthcheck/handler.go
+++ b/healthcheck/handler.go
@@ -85,14 +85,14 @@ func (hc *HealthCheck) getCheckStatus(c *Check) string {
 
 		// Global state will be considered critical if check has been critical for longer
 		// than the first critical error since last success and the timeout has expired.
-		criticalTimeThreshold := hc.TimeOfFirstCriticalError.Add(hc.CriticalErrorTimeout)
-		if lastSuccess.Before(hc.TimeOfFirstCriticalError) && now.After(criticalTimeThreshold) {
+		criticalTimeThreshold := hc.timeOfFirstCriticalError.Add(hc.criticalErrorTimeout)
+		if lastSuccess.Before(hc.timeOfFirstCriticalError) && now.After(criticalTimeThreshold) {
 			status = StatusCritical
 		}
 
 		// Set timestamp of first critical error to now if there has been a success since the previous value, or if this is the first one.
-		if lastSuccess.After(hc.TimeOfFirstCriticalError) || hc.TimeOfFirstCriticalError.IsZero() {
-			hc.TimeOfFirstCriticalError = now
+		if lastSuccess.After(hc.timeOfFirstCriticalError) || hc.timeOfFirstCriticalError.IsZero() {
+			hc.timeOfFirstCriticalError = now
 		}
 
 		return status

--- a/healthcheck/handler.go
+++ b/healthcheck/handler.go
@@ -9,8 +9,10 @@ import (
 	"github.com/ONSdigital/log.go/log"
 )
 
+var minTime = time.Unix(0, 0)
+
 // Handler responds to an http request for the current health status
-func (hc HealthCheck) Handler(w http.ResponseWriter, req *http.Request) {
+func (hc *HealthCheck) Handler(w http.ResponseWriter, req *http.Request) {
 	now := time.Now().UTC()
 	ctx := req.Context()
 
@@ -31,7 +33,7 @@ func (hc HealthCheck) Handler(w http.ResponseWriter, req *http.Request) {
 }
 
 // isAppStartingUp returns false when all clients have completed at least one check
-func (hc HealthCheck) isAppStartingUp() bool {
+func (hc *HealthCheck) isAppStartingUp() bool {
 	for _, check := range hc.Checks {
 		if !check.hasRun() {
 			return true
@@ -41,7 +43,7 @@ func (hc HealthCheck) isAppStartingUp() bool {
 }
 
 // getStatus returns a status as string as to the overall current apps health based on its dependent apps health
-func (hc HealthCheck) getStatus(ctx context.Context) string {
+func (hc *HealthCheck) getStatus(ctx context.Context) string {
 	if hc.isAppStartingUp() {
 		log.Event(ctx, "a dependency is still starting up")
 		return StatusWarning
@@ -50,7 +52,7 @@ func (hc HealthCheck) getStatus(ctx context.Context) string {
 }
 
 // isAppHealthy checks every check for their health then produces and returns a status for this apps health
-func (hc HealthCheck) isAppHealthy() string {
+func (hc *HealthCheck) isAppHealthy() string {
 	status := StatusOK
 	for _, check := range hc.Checks {
 		checkStatus := hc.getCheckStatus(check)
@@ -64,7 +66,7 @@ func (hc HealthCheck) isAppHealthy() string {
 }
 
 // getCheckStatus returns a string for the status on if an individual check
-func (hc HealthCheck) getCheckStatus(c *Check) string {
+func (hc *HealthCheck) getCheckStatus(c *Check) string {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
@@ -74,16 +76,27 @@ func (hc HealthCheck) getCheckStatus(c *Check) string {
 	case StatusWarning:
 		return StatusWarning
 	default:
+
 		now := time.Now().UTC()
 		status := StatusWarning
+
+		// last success or minTime if nil. c should not be muted.
+		lastSuccess := &minTime
+		if c.state.LastSuccess != nil {
+			lastSuccess = c.state.LastSuccess
+		}
+
+		// Global state will be considered critical if check has been critical for longer than the first critical error since last success and the timeout has expired.
 		criticalTimeThreshold := hc.TimeOfFirstCriticalError.Add(hc.CriticalErrorTimeout)
-		if c.state.LastSuccess.Before(hc.TimeOfFirstCriticalError) && now.After(criticalTimeThreshold) {
+		if lastSuccess.Before(hc.TimeOfFirstCriticalError) && now.After(criticalTimeThreshold) {
 			status = StatusCritical
 		}
-		// Set timestamp of first critical error to now
-		if c.state.LastSuccess.After(hc.TimeOfFirstCriticalError) {
+
+		// Set timestamp of first critical error to now if there has been a success since the previous value, or if this is the first one.
+		if lastSuccess.After(hc.TimeOfFirstCriticalError) || hc.TimeOfFirstCriticalError.IsZero() {
 			hc.TimeOfFirstCriticalError = now
 		}
+
 		return status
 	}
 }

--- a/healthcheck/handler.go
+++ b/healthcheck/handler.go
@@ -86,7 +86,8 @@ func (hc *HealthCheck) getCheckStatus(c *Check) string {
 			lastSuccess = c.state.LastSuccess
 		}
 
-		// Global state will be considered critical if check has been critical for longer than the first critical error since last success and the timeout has expired.
+		// Global state will be considered critical if check has been critical for longer
+		// than the first critical error since last success and the timeout has expired.
 		criticalTimeThreshold := hc.TimeOfFirstCriticalError.Add(hc.CriticalErrorTimeout)
 		if lastSuccess.Before(hc.TimeOfFirstCriticalError) && now.After(criticalTimeThreshold) {
 			status = StatusCritical

--- a/healthcheck/handler.go
+++ b/healthcheck/handler.go
@@ -17,7 +17,7 @@ func (hc *HealthCheck) Handler(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
 	hc.Status = hc.getStatus(ctx)
-	hc.Uptime = now.Sub(hc.StartTime)
+	hc.Uptime = now.Sub(hc.StartTime) / time.Millisecond
 
 	b, err := json.Marshal(hc)
 	if err != nil {

--- a/healthcheck/handler.go
+++ b/healthcheck/handler.go
@@ -67,10 +67,7 @@ func (hc *HealthCheck) isAppHealthy() string {
 
 // getCheckStatus returns a string for the status on if an individual check
 func (hc *HealthCheck) getCheckStatus(c *Check) string {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	switch c.state.Status {
+	switch c.state.Status() {
 	case StatusOK:
 		return StatusOK
 	case StatusWarning:
@@ -81,9 +78,9 @@ func (hc *HealthCheck) getCheckStatus(c *Check) string {
 		status := StatusWarning
 
 		// last success or minTime if nil. c should not be muted.
-		lastSuccess := &minTime
-		if c.state.LastSuccess != nil {
-			lastSuccess = c.state.LastSuccess
+		lastSuccess := c.state.LastSuccess()
+		if lastSuccess == nil {
+			lastSuccess = &minTime
 		}
 
 		// Global state will be considered critical if check has been critical for longer

--- a/healthcheck/handler_test.go
+++ b/healthcheck/handler_test.go
@@ -185,7 +185,7 @@ func TestGetCheckStatus(t *testing.T) {
 		check := &Check{
 			state: &CheckState{
 				status: StatusOK,
-				mutex: &sync.RWMutex{},
+				mutex:  &sync.RWMutex{},
 			},
 		}
 
@@ -197,7 +197,7 @@ func TestGetCheckStatus(t *testing.T) {
 		check := &Check{
 			state: &CheckState{
 				status: StatusWarning,
-				mutex: &sync.RWMutex{},
+				mutex:  &sync.RWMutex{},
 			},
 		}
 
@@ -212,7 +212,7 @@ func TestGetCheckStatus(t *testing.T) {
 				check := &Check{
 					state: &CheckState{
 						status: StatusCritical,
-						mutex: &sync.RWMutex{},
+						mutex:  &sync.RWMutex{},
 					},
 				}
 
@@ -231,7 +231,7 @@ func TestGetCheckStatus(t *testing.T) {
 				check := &Check{
 					state: &CheckState{
 						status: StatusCritical,
-						mutex: &sync.RWMutex{},
+						mutex:  &sync.RWMutex{},
 					},
 				}
 
@@ -249,7 +249,7 @@ func TestGetCheckStatus(t *testing.T) {
 				check := &Check{
 					state: &CheckState{
 						status: StatusCritical,
-						mutex: &sync.RWMutex{},
+						mutex:  &sync.RWMutex{},
 					},
 				}
 
@@ -269,7 +269,7 @@ func TestGetCheckStatus(t *testing.T) {
 					state: &CheckState{
 						status:      StatusCritical,
 						lastSuccess: &t9,
-						mutex: &sync.RWMutex{},
+						mutex:       &sync.RWMutex{},
 					},
 				}
 
@@ -783,7 +783,7 @@ func createATestCheck(stateToReturn CheckState, hasPreviousCheck bool) *Check {
 		state.lastFailure = stateToReturn.lastFailure
 		return nil
 	}
-	check, _ := newCheck(checkerFunc)
+	check, _ := NewCheck(checkerFunc)
 	if hasPreviousCheck {
 		check.state.name = stateToReturn.name
 		check.state.status = stateToReturn.status
@@ -836,7 +836,7 @@ func runHealthHandlerAndTest(t *testing.T, hc *HealthCheck, desiredStatus string
 		return
 	}
 	So(w.Code, ShouldEqual, http.StatusOK)
-	// So(healthCheck.Status, ShouldEqual, desiredStatus)
+	So(healthCheck.Status, ShouldEqual, desiredStatus)
 	So(healthCheck.Version, ShouldResemble, testVersion)
 	So(healthCheck.StartTime, ShouldEqual, testStartTime)
 	So(healthCheck.Uptime, ShouldNotBeNil)

--- a/healthcheck/handler_test.go
+++ b/healthcheck/handler_test.go
@@ -774,7 +774,6 @@ func TestHandlerMultipleChecks(t *testing.T) {
 
 func createATestCheck(stateToReturn CheckState, hasPreviousCheck bool) *Check {
 	checkerFunc := func(ctx context.Context, state *CheckState) error {
-		state.name = stateToReturn.name
 		state.status = stateToReturn.status
 		state.message = stateToReturn.message
 		state.statusCode = stateToReturn.statusCode
@@ -783,9 +782,8 @@ func createATestCheck(stateToReturn CheckState, hasPreviousCheck bool) *Check {
 		state.lastFailure = stateToReturn.lastFailure
 		return nil
 	}
-	check, _ := NewCheck(checkerFunc)
+	check, _ := NewCheck(stateToReturn.name, checkerFunc)
 	if hasPreviousCheck {
-		check.state.name = stateToReturn.name
 		check.state.status = stateToReturn.status
 		check.state.message = stateToReturn.message
 		check.state.statusCode = stateToReturn.statusCode

--- a/healthcheck/handler_test.go
+++ b/healthcheck/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,76 +22,437 @@ var testVersion = VersionInfo{
 	Version:         "1.0.0",
 }
 
-func createATestCheck(stateToReturn CheckState, pretendHistory bool) *Check {
-	checkerFunc := func(ctx context.Context, state *CheckState) error {
-		if pretendHistory {
-			state = &stateToReturn
-		}
-		return nil
-	}
-	check, _ := newCheck(checkerFunc)
-	if pretendHistory {
-		check.state = &stateToReturn
-	}
-	return check
+// Test getStatus() function that inherits logic from isAppStartingUp() and isAppHealthy()
+func TestGetStatus(t *testing.T) {
+	t0 := time.Now().UTC()
+	criticalErrTimeout := 10 * time.Minute
+	ctx := context.Background()
+
+	Convey("Given application is still starting up", t, func() {
+		Convey("Then the app has a health state of WARNING", func() {
+			// Create health check object
+			hc := HealthCheck{
+				Version:              testVersion,
+				StartTime:            t0,
+				CriticalErrorTimeout: criticalErrTimeout,
+				Tickers:              nil,
+			}
+
+			// Adding checks
+			statuses := []CheckState{CheckState{}}
+			hc.Checks = createChecksSlice(statuses, true)
+
+			state := hc.getStatus(ctx)
+			So(state, ShouldEqual, StatusWarning)
+		})
+	})
+
+	Convey("Given application has started up successfully", t, func() {
+		Convey("Then the app has a health state of OK", func() {
+			// Create health check object
+			hc := HealthCheck{
+				Version:              testVersion,
+				StartTime:            t0,
+				CriticalErrorTimeout: criticalErrTimeout,
+				Tickers:              nil,
+			}
+
+			// Adding checks
+			statuses := []CheckState{CheckState{Status: StatusOK, LastChecked: &t0}}
+			hc.Checks = createChecksSlice(statuses, true)
+
+			state := hc.getStatus(ctx)
+			So(state, ShouldEqual, StatusOK)
+		})
+	})
 }
 
-func createHealthCheck(statuses []CheckState, startTime time.Time, critErrTimeout time.Duration, pretendHistory bool) HealthCheck {
+// Test isAppStartingUp() function
+func TestIsAppStartingUP(t *testing.T) {
+	t0 := time.Now().UTC()
+	criticalErrTimeout := 10 * time.Minute
+
+	Convey("Given no checks against healthcheck", t, func() {
+		Convey("Then the app has not started up", func() {
+			// Create health check object
+			hc := HealthCheck{
+				Version:              testVersion,
+				StartTime:            t0,
+				CriticalErrorTimeout: criticalErrTimeout,
+				Tickers:              nil,
+			}
+
+			isStarting := hc.isAppStartingUp()
+			So(isStarting, ShouldEqual, false)
+		})
+	})
+
+	Convey("Given a healthcheck with a single check without a lastChecked timestamp", t, func() {
+		Convey("Then the app has not started up", func() {
+			// Create health check object
+			hc := HealthCheck{
+				Version:              testVersion,
+				StartTime:            t0,
+				CriticalErrorTimeout: criticalErrTimeout,
+				Tickers:              nil,
+			}
+
+			// Adding checks
+			statuses := []CheckState{CheckState{}}
+			hc.Checks = createChecksSlice(statuses, true)
+
+			isStarting := hc.isAppStartingUp()
+			So(isStarting, ShouldEqual, true)
+		})
+	})
+
+	Convey("Given a healthcheck with a single check with a lastChecked timestamp", t, func() {
+		Convey("Then the app has not started up", func() {
+			// Create health check object
+			hc := HealthCheck{
+				Version:              testVersion,
+				StartTime:            t0,
+				CriticalErrorTimeout: criticalErrTimeout,
+				Tickers:              nil,
+			}
+
+			// Adding checks
+			statuses := []CheckState{CheckState{LastChecked: &t0}}
+			hc.Checks = createChecksSlice(statuses, true)
+
+			isStarting := hc.isAppStartingUp()
+			So(isStarting, ShouldEqual, false)
+		})
+	})
+
+	Convey("Given a healthcheck with two checks both with a lastChecked timestamp", t, func() {
+		Convey("Then the app has not started up", func() {
+			// Create health check object
+			hc := HealthCheck{
+				Version:              testVersion,
+				StartTime:            t0,
+				CriticalErrorTimeout: criticalErrTimeout,
+				Tickers:              nil,
+			}
+
+			// Adding checks
+			statuses := []CheckState{CheckState{LastChecked: &t0}, CheckState{LastChecked: &t0}}
+			hc.Checks = createChecksSlice(statuses, true)
+
+			isStarting := hc.isAppStartingUp()
+			So(isStarting, ShouldEqual, false)
+		})
+	})
+
+	Convey("Given a healthcheck with two checks with at least one without a lastChecked timestamp", t, func() {
+		Convey("Then the app has started up", func() {
+			// Create health check object
+			hc := HealthCheck{
+				Version:              testVersion,
+				StartTime:            t0,
+				CriticalErrorTimeout: criticalErrTimeout,
+				Tickers:              nil,
+			}
+
+			// Adding checks
+			statuses := []CheckState{CheckState{LastChecked: &t0}, CheckState{}}
+			hc.Checks = createChecksSlice(statuses, true)
+
+			isStarting := hc.isAppStartingUp()
+			So(isStarting, ShouldEqual, true)
+		})
+	})
+}
+
+// Test getCheckStatus() function
+func TestGetCheckStatus(t *testing.T) {
+	t0 := time.Now().UTC()
+	t9 := t0.Add(-9 * time.Minute)   // 9 min ago
+	t10 := t0.Add(-10 * time.Minute) // 10 min ago
+	t20 := t0.Add(-20 * time.Minute) // 20 min ago
+
+	criticalErrTimeout := 10 * time.Minute
+
+	// Create empty health check object
 	hc := HealthCheck{
-		Checks:               createChecksSlice(statuses, pretendHistory),
 		Version:              testVersion,
-		StartTime:            startTime,
-		CriticalErrorTimeout: critErrTimeout,
+		StartTime:            t0,
+		CriticalErrorTimeout: criticalErrTimeout,
 		Tickers:              nil,
 	}
-	return hc
-}
 
-func createChecksSlice(statuses []CheckState, pretendHistory bool) []*Check {
-	var checks []*Check
-	for _, status := range statuses {
-		checks = append(checks, createATestCheck(status, pretendHistory))
-	}
-	return checks
-}
-
-func runHealthHandlerAndTest(t *testing.T, hc *HealthCheck, desiredStatus string, testVersion VersionInfo, testStartTime time.Time, statuses []CheckState) {
-	req, err := http.NewRequest("GET", "/health", nil)
-	if err != nil {
-		t.Fail()
-	}
-	w := httptest.NewRecorder()
-	handler := http.HandlerFunc(hc.Handler)
-	handler.ServeHTTP(w, req)
-	b, err := ioutil.ReadAll(w.Body)
-	if err != nil {
-		log.Event(nil, "unable to read request body", log.Error(err))
-	}
-	var healthCheck HealthCheck
-	err = json.Unmarshal(b, &healthCheck)
-	if err != nil {
-		log.Event(nil, "unable to unmarshal bytes into healthcheck", log.Error(err))
-
-		So(err, ShouldBeNil)
-		return
-	}
-	So(w.Code, ShouldEqual, http.StatusOK)
-	So(healthCheck.Status, ShouldEqual, desiredStatus)
-	So(healthCheck.Version, ShouldResemble, testVersion)
-	So(healthCheck.StartTime, ShouldEqual, testStartTime)
-	So(healthCheck.Uptime, ShouldNotBeNil)
-	So(time.Now().UTC().After(healthCheck.StartTime.Add(healthCheck.Uptime)), ShouldBeTrue)
-
-	if statuses != nil {
-		for i, check := range healthCheck.Checks {
-			So(*check.state, ShouldResemble, statuses[i])
+	Convey("Given check status is okay return OK", t, func() {
+		check := &Check{
+			state: &CheckState{
+				Status: StatusOK,
+			},
+			mutex: &sync.Mutex{},
 		}
-	} else {
 
-	}
+		status := hc.getCheckStatus(check)
+		So(status, ShouldEqual, StatusOK)
+	})
+
+	Convey("Given check status is warning return warning", t, func() {
+		check := &Check{
+			state: &CheckState{
+				Status: StatusWarning,
+			},
+			mutex: &sync.Mutex{},
+		}
+
+		status := hc.getCheckStatus(check)
+		So(status, ShouldEqual, StatusWarning)
+	})
+
+	Convey("Given check status is failure", t, func() {
+		Convey("When check is without last successful state and time of first critical state"+
+			"is greater than the critical timeout", func() {
+			Convey("Then the returning status is critical", func() {
+				check := &Check{
+					state: &CheckState{
+						Status: StatusCritical,
+					},
+					mutex: &sync.Mutex{},
+				}
+
+				hc.TimeOfFirstCriticalError = t20
+
+				status := hc.getCheckStatus(check)
+				So(status, ShouldEqual, StatusCritical)
+				So(hc.TimeOfFirstCriticalError, ShouldEqual, t20)
+			})
+		})
+
+		Convey("When check is without last successful state and time of first critical state"+
+			"is equal to the critical timeout", func() {
+
+			Convey("Then the returning status is critical", func() {
+				check := &Check{
+					state: &CheckState{
+						Status: StatusCritical,
+					},
+					mutex: &sync.Mutex{},
+				}
+
+				hc.TimeOfFirstCriticalError = t10
+
+				status := hc.getCheckStatus(check)
+				So(status, ShouldEqual, StatusCritical)
+				So(hc.TimeOfFirstCriticalError, ShouldEqual, t10)
+			})
+		})
+
+		Convey("When check is without last successful state and time of first critical state"+
+			"is less than the critical timeout", func() {
+			Convey("Then the returning status is warning", func() {
+				check := &Check{
+					state: &CheckState{
+						Status: StatusCritical,
+					},
+					mutex: &sync.Mutex{},
+				}
+
+				hc.TimeOfFirstCriticalError = t9
+
+				status := hc.getCheckStatus(check)
+				So(status, ShouldEqual, StatusWarning)
+				So(hc.TimeOfFirstCriticalError, ShouldEqual, t9)
+				So(check.state.LastSuccess, ShouldBeNil)
+			})
+		})
+
+		Convey("When time of first critical state is less than the critical timeout"+
+			"but the check has a last successful state that occurred within the critical timeout", func() {
+			Convey("Then the returning status is warning", func() {
+				check := &Check{
+					state: &CheckState{
+						Status:      StatusCritical,
+						LastSuccess: &t9,
+					},
+					mutex: &sync.Mutex{},
+				}
+
+				hc.TimeOfFirstCriticalError = t10
+
+				status := hc.getCheckStatus(check)
+				So(status, ShouldEqual, StatusWarning)
+				So(hc.TimeOfFirstCriticalError, ShouldHappenBetween, t0, time.Now().UTC())
+				So(check.state.LastSuccess, ShouldEqual, &t9)
+			})
+		})
+	})
 }
 
-func TestHandlerSignleCheck(t *testing.T) {
+// Testing isAppHealthy() function that inherits logic from getCheckStatus()
+func TestIsAppHealthy(t *testing.T) {
+
+	criticalErrTimeout := 10 * time.Minute
+
+	t0 := time.Now().UTC()
+	t1 := t0.Add(-1 * time.Minute)   // 1 min ago
+	t10 := t0.Add(-10 * time.Minute) // 10 min ago
+	t20 := t0.Add(-20 * time.Minute) // 20 min ago
+
+	healthyCheck := CheckState{
+		Name:        "service-1",
+		Status:      StatusOK,
+		StatusCode:  http.StatusOK,
+		Message:     "Service is healthy",
+		LastChecked: &t1,
+		LastSuccess: &t1,
+	}
+
+	warningCheck := CheckState{
+		Name:        "service-2",
+		Status:      StatusWarning,
+		StatusCode:  http.StatusTooManyRequests,
+		Message:     "Part of service is unavailable",
+		LastChecked: &t1,
+		LastSuccess: &t10,
+	}
+
+	criticalCheck := CheckState{
+		Name:        "service-3",
+		Status:      StatusCritical,
+		StatusCode:  http.StatusInternalServerError,
+		Message:     "Service is unavailable",
+		LastChecked: &t1,
+		LastSuccess: &t20,
+		LastFailure: &t1,
+	}
+
+	Convey("Given healthcheck contains two checks, both with statuses of OK", t, func() {
+		Convey("Then the returning status is OK", func() {
+
+			// Create health check object
+			hc := HealthCheck{
+				Version:              testVersion,
+				StartTime:            t0,
+				CriticalErrorTimeout: criticalErrTimeout,
+				Tickers:              nil,
+			}
+
+			// Adding two healthy checks
+			statuses := []CheckState{healthyCheck, healthyCheck}
+			hc.Checks = createChecksSlice(statuses, true)
+
+			status := hc.isAppHealthy()
+			So(status, ShouldEqual, StatusOK)
+		})
+	})
+
+	Convey("Given healthcheck contains two checks, one with status of OK"+
+		"and the other with status WARNING", t, func() {
+		Convey("Then the returning status is WARNING", func() {
+
+			// Create health check object
+			hc := HealthCheck{
+				Version:              testVersion,
+				StartTime:            t0,
+				CriticalErrorTimeout: criticalErrTimeout,
+				Tickers:              nil,
+			}
+
+			// Adding two healthy checks
+			statuses := []CheckState{healthyCheck, warningCheck}
+			hc.Checks = createChecksSlice(statuses, true)
+
+			status := hc.isAppHealthy()
+			So(status, ShouldEqual, StatusWarning)
+		})
+	})
+
+	Convey("Given healthcheck contains two checks, one with status of OK"+
+		"and the other with status CRITICAL but has not succeeded the critical timeout", t, func() {
+		Convey("Then the returning status is WARNING", func() {
+
+			// Create health check object
+			hc := HealthCheck{
+				Version:                  testVersion,
+				StartTime:                t20,
+				CriticalErrorTimeout:     criticalErrTimeout,
+				Tickers:                  nil,
+				TimeOfFirstCriticalError: t1,
+			}
+
+			// Adding two healthy checks
+			statuses := []CheckState{healthyCheck, criticalCheck}
+			hc.Checks = createChecksSlice(statuses, true)
+
+			status := hc.isAppHealthy()
+			So(status, ShouldEqual, StatusWarning)
+		})
+	})
+
+	Convey("Given healthcheck contains two checks, one with status of OK"+
+		"and the other with status CRITICAL that has succeeded the critical timeout", t, func() {
+		Convey("Then the returning status is CRITICAL", func() {
+
+			// Create health check object
+			hc := HealthCheck{
+				Version:                  testVersion,
+				StartTime:                t20,
+				CriticalErrorTimeout:     criticalErrTimeout,
+				Tickers:                  nil,
+				TimeOfFirstCriticalError: t10,
+			}
+
+			// Adding two healthy checks
+			statuses := []CheckState{healthyCheck, criticalCheck}
+			hc.Checks = createChecksSlice(statuses, true)
+
+			status := hc.isAppHealthy()
+			So(status, ShouldEqual, StatusCritical)
+		})
+	})
+
+	Convey("Given healthcheck contains two checks, one with status of WARNING"+
+		"and the other with status CRITICAL but has not succeeded the critical timeout", t, func() {
+		Convey("Then the returning status is WARNING", func() {
+
+			// Create health check object
+			hc := HealthCheck{
+				Version:                  testVersion,
+				StartTime:                t20,
+				CriticalErrorTimeout:     criticalErrTimeout,
+				Tickers:                  nil,
+				TimeOfFirstCriticalError: t1,
+			}
+
+			// Adding two healthy checks
+			statuses := []CheckState{warningCheck, criticalCheck}
+			hc.Checks = createChecksSlice(statuses, true)
+
+			status := hc.isAppHealthy()
+			So(status, ShouldEqual, StatusWarning)
+		})
+	})
+
+	Convey("Given healthcheck contains two checks, one with status of WARNING"+
+		"and the other with status CRITICAL and has succeeded the critical timeout", t, func() {
+		Convey("Then the returning status is CRITICAL", func() {
+
+			// Create health check object
+			hc := HealthCheck{
+				Version:                  testVersion,
+				StartTime:                t20,
+				CriticalErrorTimeout:     criticalErrTimeout,
+				Tickers:                  nil,
+				TimeOfFirstCriticalError: t10,
+			}
+
+			// Adding two healthy checks
+			statuses := []CheckState{warningCheck, criticalCheck}
+			hc.Checks = createChecksSlice(statuses, true)
+
+			status := hc.isAppHealthy()
+			So(status, ShouldEqual, StatusCritical)
+		})
+	})
+}
+
+func TestHandlerSingleCheck(t *testing.T) {
 	t0 := time.Now().UTC()
 	t10 := t0.Add(-10 * time.Minute) // 10 min ago
 	t20 := t0.Add(-20 * time.Minute) // 20 min ago
@@ -171,49 +533,50 @@ func TestHandlerSignleCheck(t *testing.T) {
 			Tickers:              nil,
 		}
 
-		Convey("An empty check should result in the app reporting back as warning", func() {
+		Convey("Then an empty check should result in the app reporting back as warning", func() {
 			statuses := []CheckState{nilStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
 			// TimeOfFirstCriticalError not set
 			So(hc.TimeOfFirstCriticalError, ShouldResemble, time.Time{})
 		})
-		Convey("A healthy check that has never been unhealthy should result in the app reporting back as healthy", func() {
+
+		Convey("Then a healthy check that has never been unhealthy should result in the app reporting back as healthy", func() {
 			statuses := []CheckState{healthyNeverUnhealthyStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusOK, testVersion, t0, statuses)
 			// TimeOfFirstCriticalError not set
 			So(hc.TimeOfFirstCriticalError, ShouldResemble, time.Time{})
 		})
-		Convey("A healthy check that has been unhealthy in the past should result in the app reporting back as healthy", func() {
+		Convey("Then a healthy check that has been unhealthy in the past should result in the app reporting back as healthy", func() {
 			statuses := []CheckState{healthyStatus1}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusOK, testVersion, t0, statuses)
 			// TimeOfFirstCriticalError not set
 			So(hc.TimeOfFirstCriticalError, ShouldResemble, time.Time{})
 		})
-		Convey("An unhealthy check that has never been healthy should result in the app reporting back as warning", func() {
+		Convey("Then an unhealthy check that has never been healthy should result in the app reporting back as warning", func() {
 			statuses := []CheckState{unhealthyNeverHealthyStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
 			// TimeOfFirstCriticalError not set
 			So(hc.TimeOfFirstCriticalError, ShouldResemble, time.Time{})
 		})
-		Convey("An unhealthy check that has been healthy in the past should result in the app reporting back as warning", func() {
+		Convey("Then an unhealthy check that has been healthy in the past should result in the app reporting back as warning", func() {
 			statuses := []CheckState{unhealthyStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
 			// TimeOfFirstCriticalError not set
 			So(hc.TimeOfFirstCriticalError, ShouldResemble, time.Time{})
 		})
-		Convey("A critical check that has never been healthy should result in the app reporting back as warning and updating timestamp for first critical error", func() {
+		Convey("Then a critical check that has never been healthy should result in the app reporting back as warning and updating timestamp for first critical error", func() {
 			statuses := []CheckState{criticalNeverHealthyStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
 			// TimeOfFirstCriticalError set to this check's failure time
 			So(hc.TimeOfFirstCriticalError, ShouldHappenWithin, time.Second, t0)
 		})
-		Convey("A critical check that has been healthy in the past should result in the app reporting back as warning and updating timestamp for first critical error", func() {
+		Convey("Then a critical check that has been healthy in the past should result in the app reporting back as warning and updating timestamp for first critical error", func() {
 			statuses := []CheckState{oldCriticalStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
@@ -232,21 +595,21 @@ func TestHandlerSignleCheck(t *testing.T) {
 			Tickers:                  nil,
 		}
 
-		Convey("A healthy check should result in the app reporting back as healthy", func() {
+		Convey("Then a healthy check should result in the app reporting back as healthy", func() {
 			statuses := []CheckState{healthyNeverUnhealthyStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusOK, testVersion, t0, statuses)
 			// TimeOfFirstCriticalError not updated
 			So(hc.TimeOfFirstCriticalError, ShouldResemble, t10)
 		})
-		Convey("A recent critical check happening before the timeout expires should result in the app reporting back as warning", func() {
+		Convey("Then a recent critical check happening before the timeout expires should result in the app reporting back as warning", func() {
 			statuses := []CheckState{freshCriticalStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
 			// TimeOfFirstCriticalError not updated
 			So(hc.TimeOfFirstCriticalError, ShouldResemble, t10)
 		})
-		Convey("A critical check that has been critical for longer than the timeout and the value of first critical error, "+
+		Convey("Then a critical check that has been critical for longer than the timeout and the value of first critical error, "+
 			"should result in the app reporting back as warning and not updating timestamp for first critical error", func() {
 			statuses := []CheckState{oldCriticalStatus}
 			hc.Checks = createChecksSlice(statuses, true)
@@ -266,14 +629,14 @@ func TestHandlerSignleCheck(t *testing.T) {
 			Tickers:                  nil,
 		}
 
-		Convey("A healthy check should result in the app reporting back as healthy", func() {
+		Convey("Then a healthy check should result in the app reporting back as healthy", func() {
 			statuses := []CheckState{healthyNeverUnhealthyStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusOK, testVersion, t0, statuses)
 			// TimeOfFirstCriticalError not set
 			So(hc.TimeOfFirstCriticalError, ShouldResemble, t20)
 		})
-		Convey("A recent critical check (last success more recent than first critical) should result in the app reporting back as warning "+
+		Convey("Then a recent critical check (last success more recent than first critical) should result in the app reporting back as warning "+
 			"and refresh timestamp for first critical error", func() {
 			statuses := []CheckState{freshCriticalStatus}
 			hc.Checks = createChecksSlice(statuses, true)
@@ -281,7 +644,7 @@ func TestHandlerSignleCheck(t *testing.T) {
 			// TimeOfFirstCriticalError set to this check's failure time
 			So(hc.TimeOfFirstCriticalError, ShouldHappenWithin, time.Second, t0)
 		})
-		Convey("A critical check (last success older than first critical) should result in the app reporting back as critical "+
+		Convey("Then a critical check (last success older than first critical) should result in the app reporting back as critical "+
 			"and not refreshing timestamp for first critical error", func() {
 			statuses := []CheckState{oldCriticalStatus}
 			hc.Checks = createChecksSlice(statuses, true)
@@ -407,4 +770,73 @@ func TestHandlerMultipleChecks(t *testing.T) {
 		}
 		runHealthHandlerAndTest(t, &hc, StatusOK, testVersion, testStartTime, statuses)
 	})
+}
+
+func createATestCheck(stateToReturn CheckState, hasPreviousCheck bool) *Check {
+	checkerFunc := func(ctx context.Context, state *CheckState) error {
+		if hasPreviousCheck {
+			state = &stateToReturn
+		}
+		return nil
+	}
+	check, _ := newCheck(checkerFunc)
+	if hasPreviousCheck {
+		check.state = &stateToReturn
+	}
+	return check
+}
+
+func createHealthCheck(statuses []CheckState, startTime time.Time, critErrTimeout time.Duration, hasPreviousCheck bool) HealthCheck {
+	hc := HealthCheck{
+		Checks:               createChecksSlice(statuses, hasPreviousCheck),
+		Version:              testVersion,
+		StartTime:            startTime,
+		CriticalErrorTimeout: critErrTimeout,
+		Tickers:              nil,
+	}
+	return hc
+}
+
+func createChecksSlice(statuses []CheckState, hasPreviousCheck bool) []*Check {
+	var checks []*Check
+	for _, status := range statuses {
+		checks = append(checks, createATestCheck(status, hasPreviousCheck))
+	}
+	return checks
+}
+
+func runHealthHandlerAndTest(t *testing.T, hc *HealthCheck, desiredStatus string, testVersion VersionInfo, testStartTime time.Time, statuses []CheckState) {
+	req, err := http.NewRequest("GET", "/health", nil)
+	if err != nil {
+		t.Fail()
+	}
+	w := httptest.NewRecorder()
+	handler := http.HandlerFunc(hc.Handler)
+	handler.ServeHTTP(w, req)
+	b, err := ioutil.ReadAll(w.Body)
+	if err != nil {
+		log.Event(nil, "unable to read request body", log.Error(err))
+	}
+	var healthCheck HealthCheck
+	err = json.Unmarshal(b, &healthCheck)
+	if err != nil {
+		log.Event(nil, "unable to unmarshal bytes into healthcheck", log.Error(err))
+
+		So(err, ShouldBeNil)
+		return
+	}
+	So(w.Code, ShouldEqual, http.StatusOK)
+	So(healthCheck.Status, ShouldEqual, desiredStatus)
+	So(healthCheck.Version, ShouldResemble, testVersion)
+	So(healthCheck.StartTime, ShouldEqual, testStartTime)
+	So(healthCheck.Uptime, ShouldNotBeNil)
+	So(time.Now().UTC().After(healthCheck.StartTime.Add(healthCheck.Uptime)), ShouldBeTrue)
+
+	if statuses != nil {
+		for i, check := range healthCheck.Checks {
+			So(*check.state, ShouldResemble, statuses[i])
+		}
+	} else {
+
+	}
 }

--- a/healthcheck/handler_test.go
+++ b/healthcheck/handler_test.go
@@ -21,15 +21,10 @@ var testVersion = VersionInfo{
 	Version:         "1.0.0",
 }
 
-func createATestChecker(stateToReturn CheckState) *Checker {
-	checkerFunc := Checker(func(ctx context.Context) (status *CheckState, err error) {
-		return &stateToReturn, nil
-	})
-	return &checkerFunc
-}
-
 func createATestCheck(stateToReturn CheckState, pretendHistory bool) *Check {
-	checkerFunc := createATestChecker(stateToReturn)
+	checkerFunc := func(ctx context.Context) (status *CheckState, err error) {
+		return &stateToReturn, nil
+	}
 	check, _ := newCheck(checkerFunc)
 	if pretendHistory {
 		check.State = &stateToReturn

--- a/healthcheck/handler_test.go
+++ b/healthcheck/handler_test.go
@@ -34,8 +34,8 @@ func TestGetStatus(t *testing.T) {
 			hc := HealthCheck{
 				Version:              testVersion,
 				StartTime:            t0,
-				CriticalErrorTimeout: criticalErrTimeout,
-				Tickers:              nil,
+				criticalErrorTimeout: criticalErrTimeout,
+				tickers:              nil,
 			}
 
 			// Adding checks
@@ -53,8 +53,8 @@ func TestGetStatus(t *testing.T) {
 			hc := HealthCheck{
 				Version:              testVersion,
 				StartTime:            t0,
-				CriticalErrorTimeout: criticalErrTimeout,
-				Tickers:              nil,
+				criticalErrorTimeout: criticalErrTimeout,
+				tickers:              nil,
 			}
 
 			// Adding checks
@@ -78,8 +78,8 @@ func TestIsAppStartingUP(t *testing.T) {
 			hc := HealthCheck{
 				Version:              testVersion,
 				StartTime:            t0,
-				CriticalErrorTimeout: criticalErrTimeout,
-				Tickers:              nil,
+				criticalErrorTimeout: criticalErrTimeout,
+				tickers:              nil,
 			}
 
 			isStarting := hc.isAppStartingUp()
@@ -93,8 +93,8 @@ func TestIsAppStartingUP(t *testing.T) {
 			hc := HealthCheck{
 				Version:              testVersion,
 				StartTime:            t0,
-				CriticalErrorTimeout: criticalErrTimeout,
-				Tickers:              nil,
+				criticalErrorTimeout: criticalErrTimeout,
+				tickers:              nil,
 			}
 
 			// Adding checks
@@ -112,8 +112,8 @@ func TestIsAppStartingUP(t *testing.T) {
 			hc := HealthCheck{
 				Version:              testVersion,
 				StartTime:            t0,
-				CriticalErrorTimeout: criticalErrTimeout,
-				Tickers:              nil,
+				criticalErrorTimeout: criticalErrTimeout,
+				tickers:              nil,
 			}
 
 			// Adding checks
@@ -131,8 +131,8 @@ func TestIsAppStartingUP(t *testing.T) {
 			hc := HealthCheck{
 				Version:              testVersion,
 				StartTime:            t0,
-				CriticalErrorTimeout: criticalErrTimeout,
-				Tickers:              nil,
+				criticalErrorTimeout: criticalErrTimeout,
+				tickers:              nil,
 			}
 
 			// Adding checks
@@ -150,8 +150,8 @@ func TestIsAppStartingUP(t *testing.T) {
 			hc := HealthCheck{
 				Version:              testVersion,
 				StartTime:            t0,
-				CriticalErrorTimeout: criticalErrTimeout,
-				Tickers:              nil,
+				criticalErrorTimeout: criticalErrTimeout,
+				tickers:              nil,
 			}
 
 			// Adding checks
@@ -177,8 +177,8 @@ func TestGetCheckStatus(t *testing.T) {
 	hc := HealthCheck{
 		Version:              testVersion,
 		StartTime:            t0,
-		CriticalErrorTimeout: criticalErrTimeout,
-		Tickers:              nil,
+		criticalErrorTimeout: criticalErrTimeout,
+		tickers:              nil,
 	}
 
 	Convey("Given check status is okay return OK", t, func() {
@@ -216,11 +216,11 @@ func TestGetCheckStatus(t *testing.T) {
 					},
 				}
 
-				hc.TimeOfFirstCriticalError = t20
+				hc.timeOfFirstCriticalError = t20
 
 				status := hc.getCheckStatus(check)
 				So(status, ShouldEqual, StatusCritical)
-				So(hc.TimeOfFirstCriticalError, ShouldEqual, t20)
+				So(hc.timeOfFirstCriticalError, ShouldEqual, t20)
 			})
 		})
 
@@ -235,11 +235,11 @@ func TestGetCheckStatus(t *testing.T) {
 					},
 				}
 
-				hc.TimeOfFirstCriticalError = t10
+				hc.timeOfFirstCriticalError = t10
 
 				status := hc.getCheckStatus(check)
 				So(status, ShouldEqual, StatusCritical)
-				So(hc.TimeOfFirstCriticalError, ShouldEqual, t10)
+				So(hc.timeOfFirstCriticalError, ShouldEqual, t10)
 			})
 		})
 
@@ -253,11 +253,11 @@ func TestGetCheckStatus(t *testing.T) {
 					},
 				}
 
-				hc.TimeOfFirstCriticalError = t9
+				hc.timeOfFirstCriticalError = t9
 
 				status := hc.getCheckStatus(check)
 				So(status, ShouldEqual, StatusWarning)
-				So(hc.TimeOfFirstCriticalError, ShouldEqual, t9)
+				So(hc.timeOfFirstCriticalError, ShouldEqual, t9)
 				So(check.state.LastSuccess(), ShouldBeNil)
 			})
 		})
@@ -273,11 +273,11 @@ func TestGetCheckStatus(t *testing.T) {
 					},
 				}
 
-				hc.TimeOfFirstCriticalError = t10
+				hc.timeOfFirstCriticalError = t10
 
 				status := hc.getCheckStatus(check)
 				So(status, ShouldEqual, StatusWarning)
-				So(hc.TimeOfFirstCriticalError, ShouldHappenBetween, t0, time.Now().UTC())
+				So(hc.timeOfFirstCriticalError, ShouldHappenBetween, t0, time.Now().UTC())
 				So(check.state.LastSuccess(), ShouldResemble, &t9)
 			})
 		})
@@ -329,8 +329,8 @@ func TestIsAppHealthy(t *testing.T) {
 			hc := HealthCheck{
 				Version:              testVersion,
 				StartTime:            t0,
-				CriticalErrorTimeout: criticalErrTimeout,
-				Tickers:              nil,
+				criticalErrorTimeout: criticalErrTimeout,
+				tickers:              nil,
 			}
 
 			// Adding two healthy checks
@@ -350,8 +350,8 @@ func TestIsAppHealthy(t *testing.T) {
 			hc := HealthCheck{
 				Version:              testVersion,
 				StartTime:            t0,
-				CriticalErrorTimeout: criticalErrTimeout,
-				Tickers:              nil,
+				criticalErrorTimeout: criticalErrTimeout,
+				tickers:              nil,
 			}
 
 			// Adding two healthy checks
@@ -371,9 +371,9 @@ func TestIsAppHealthy(t *testing.T) {
 			hc := HealthCheck{
 				Version:                  testVersion,
 				StartTime:                t20,
-				CriticalErrorTimeout:     criticalErrTimeout,
-				Tickers:                  nil,
-				TimeOfFirstCriticalError: t1,
+				criticalErrorTimeout:     criticalErrTimeout,
+				tickers:                  nil,
+				timeOfFirstCriticalError: t1,
 			}
 
 			// Adding two healthy checks
@@ -393,9 +393,9 @@ func TestIsAppHealthy(t *testing.T) {
 			hc := HealthCheck{
 				Version:                  testVersion,
 				StartTime:                t20,
-				CriticalErrorTimeout:     criticalErrTimeout,
-				Tickers:                  nil,
-				TimeOfFirstCriticalError: t10,
+				criticalErrorTimeout:     criticalErrTimeout,
+				tickers:                  nil,
+				timeOfFirstCriticalError: t10,
 			}
 
 			// Adding two healthy checks
@@ -415,9 +415,9 @@ func TestIsAppHealthy(t *testing.T) {
 			hc := HealthCheck{
 				Version:                  testVersion,
 				StartTime:                t20,
-				CriticalErrorTimeout:     criticalErrTimeout,
-				Tickers:                  nil,
-				TimeOfFirstCriticalError: t1,
+				criticalErrorTimeout:     criticalErrTimeout,
+				tickers:                  nil,
+				timeOfFirstCriticalError: t1,
 			}
 
 			// Adding two healthy checks
@@ -437,9 +437,9 @@ func TestIsAppHealthy(t *testing.T) {
 			hc := HealthCheck{
 				Version:                  testVersion,
 				StartTime:                t20,
-				CriticalErrorTimeout:     criticalErrTimeout,
-				Tickers:                  nil,
-				TimeOfFirstCriticalError: t10,
+				criticalErrorTimeout:     criticalErrTimeout,
+				tickers:                  nil,
+				timeOfFirstCriticalError: t10,
 			}
 
 			// Adding two healthy checks
@@ -529,59 +529,59 @@ func TestHandlerSingleCheck(t *testing.T) {
 		hc := HealthCheck{
 			Version:              testVersion,
 			StartTime:            t0,
-			CriticalErrorTimeout: criticalErrTimeout,
-			Tickers:              nil,
+			criticalErrorTimeout: criticalErrTimeout,
+			tickers:              nil,
 		}
 
 		Convey("Then an empty check should result in the app reporting back as warning", func() {
 			statuses := []CheckState{nilStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError not set
-			So(hc.TimeOfFirstCriticalError, ShouldResemble, time.Time{})
+			// timeOfFirstCriticalError not set
+			So(hc.timeOfFirstCriticalError, ShouldResemble, time.Time{})
 		})
 
 		Convey("Then a healthy check that has never been unhealthy should result in the app reporting back as healthy", func() {
 			statuses := []CheckState{healthyNeverUnhealthyStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusOK, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError not set
-			So(hc.TimeOfFirstCriticalError, ShouldResemble, time.Time{})
+			// timeOfFirstCriticalError not set
+			So(hc.timeOfFirstCriticalError, ShouldResemble, time.Time{})
 		})
 		Convey("Then a healthy check that has been unhealthy in the past should result in the app reporting back as healthy", func() {
 			statuses := []CheckState{healthyStatus1}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusOK, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError not set
-			So(hc.TimeOfFirstCriticalError, ShouldResemble, time.Time{})
+			// timeOfFirstCriticalError not set
+			So(hc.timeOfFirstCriticalError, ShouldResemble, time.Time{})
 		})
 		Convey("Then an unhealthy check that has never been healthy should result in the app reporting back as warning", func() {
 			statuses := []CheckState{unhealthyNeverHealthyStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError not set
-			So(hc.TimeOfFirstCriticalError, ShouldResemble, time.Time{})
+			// timeOfFirstCriticalError not set
+			So(hc.timeOfFirstCriticalError, ShouldResemble, time.Time{})
 		})
 		Convey("Then an unhealthy check that has been healthy in the past should result in the app reporting back as warning", func() {
 			statuses := []CheckState{unhealthyStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError not set
-			So(hc.TimeOfFirstCriticalError, ShouldResemble, time.Time{})
+			// timeOfFirstCriticalError not set
+			So(hc.timeOfFirstCriticalError, ShouldResemble, time.Time{})
 		})
 		Convey("Then a critical check that has never been healthy should result in the app reporting back as warning and updating timestamp for first critical error", func() {
 			statuses := []CheckState{criticalNeverHealthyStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError set to this check's failure time
-			So(hc.TimeOfFirstCriticalError, ShouldHappenWithin, time.Second, t0)
+			// timeOfFirstCriticalError set to this check's failure time
+			So(hc.timeOfFirstCriticalError, ShouldHappenWithin, time.Second, t0)
 		})
 		Convey("Then a critical check that has been healthy in the past should result in the app reporting back as warning and updating timestamp for first critical error", func() {
 			statuses := []CheckState{oldCriticalStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError set to this check's failure time
-			So(hc.TimeOfFirstCriticalError, ShouldHappenWithin, time.Second, t0)
+			// timeOfFirstCriticalError set to this check's failure time
+			So(hc.timeOfFirstCriticalError, ShouldHappenWithin, time.Second, t0)
 		})
 	})
 
@@ -590,32 +590,32 @@ func TestHandlerSingleCheck(t *testing.T) {
 		hc := HealthCheck{
 			Version:                  testVersion,
 			StartTime:                t0,
-			CriticalErrorTimeout:     criticalErrTimeout,
-			TimeOfFirstCriticalError: t10,
-			Tickers:                  nil,
+			criticalErrorTimeout:     criticalErrTimeout,
+			timeOfFirstCriticalError: t10,
+			tickers:                  nil,
 		}
 
 		Convey("Then a healthy check should result in the app reporting back as healthy", func() {
 			statuses := []CheckState{healthyNeverUnhealthyStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusOK, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError not updated
-			So(hc.TimeOfFirstCriticalError, ShouldResemble, t10)
+			// timeOfFirstCriticalError not updated
+			So(hc.timeOfFirstCriticalError, ShouldResemble, t10)
 		})
 		Convey("Then a recent critical check happening before the timeout expires should result in the app reporting back as warning", func() {
 			statuses := []CheckState{freshCriticalStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError not updated
-			So(hc.TimeOfFirstCriticalError, ShouldResemble, t10)
+			// timeOfFirstCriticalError not updated
+			So(hc.timeOfFirstCriticalError, ShouldResemble, t10)
 		})
 		Convey("Then a critical check that has been critical for longer than the timeout and the value of first critical error, "+
 			"should result in the app reporting back as warning and not updating timestamp for first critical error", func() {
 			statuses := []CheckState{oldCriticalStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError not updated
-			So(hc.TimeOfFirstCriticalError, ShouldResemble, t10)
+			// timeOfFirstCriticalError not updated
+			So(hc.timeOfFirstCriticalError, ShouldResemble, t10)
 		})
 	})
 
@@ -624,33 +624,33 @@ func TestHandlerSingleCheck(t *testing.T) {
 		hc := HealthCheck{
 			Version:                  testVersion,
 			StartTime:                t0,
-			CriticalErrorTimeout:     criticalErrTimeout,
-			TimeOfFirstCriticalError: t20,
-			Tickers:                  nil,
+			criticalErrorTimeout:     criticalErrTimeout,
+			timeOfFirstCriticalError: t20,
+			tickers:                  nil,
 		}
 
 		Convey("Then a healthy check should result in the app reporting back as healthy", func() {
 			statuses := []CheckState{healthyNeverUnhealthyStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusOK, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError not set
-			So(hc.TimeOfFirstCriticalError, ShouldResemble, t20)
+			// timeOfFirstCriticalError not set
+			So(hc.timeOfFirstCriticalError, ShouldResemble, t20)
 		})
 		Convey("Then a recent critical check (last success more recent than first critical) should result in the app reporting back as warning "+
 			"and refresh timestamp for first critical error", func() {
 			statuses := []CheckState{freshCriticalStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError set to this check's failure time
-			So(hc.TimeOfFirstCriticalError, ShouldHappenWithin, time.Second, t0)
+			// timeOfFirstCriticalError set to this check's failure time
+			So(hc.timeOfFirstCriticalError, ShouldHappenWithin, time.Second, t0)
 		})
 		Convey("Then a critical check (last success older than first critical) should result in the app reporting back as critical "+
 			"and not refreshing timestamp for first critical error", func() {
 			statuses := []CheckState{oldCriticalStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusCritical, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError set to this check's failure time
-			So(hc.TimeOfFirstCriticalError, ShouldResemble, t20)
+			// timeOfFirstCriticalError set to this check's failure time
+			So(hc.timeOfFirstCriticalError, ShouldResemble, t20)
 		})
 	})
 
@@ -716,45 +716,45 @@ func TestHandlerMultipleChecks(t *testing.T) {
 	Convey("Given a complete Healthy set of checks the app should report back as healthy", t, func() {
 		statuses := []CheckState{healthyStatus1, healthyStatus2, healthyStatus3}
 		hc := createHealthCheck(statuses, testStartTime, 10*time.Minute, true)
-		hc.TimeOfFirstCriticalError = testStartTime.Add(-30 * time.Minute)
+		hc.timeOfFirstCriticalError = testStartTime.Add(-30 * time.Minute)
 		runHealthHandlerAndTest(t, &hc, StatusOK, testVersion, testStartTime, statuses)
 	})
 	Convey("Given a healthy app and an unhealthy app", t, func() {
 		statuses := []CheckState{healthyStatus1, unhealthyStatus}
 		hc := createHealthCheck(statuses, testStartTime, 15*time.Second, true)
-		hc.TimeOfFirstCriticalError = testStartTime.Add(-30 * time.Minute)
+		hc.timeOfFirstCriticalError = testStartTime.Add(-30 * time.Minute)
 		runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, testStartTime, statuses)
 	})
 	Convey("Given a healthy app and a critical app that is beyond the threshold", t, func() {
 		checks := []CheckState{healthyStatus1, criticalStatus}
 		hc := createHealthCheck(checks, testStartTime, 10*time.Minute, true)
-		hc.TimeOfFirstCriticalError = testStartTime.Add(-22 * time.Minute)
+		hc.timeOfFirstCriticalError = testStartTime.Add(-22 * time.Minute)
 		runHealthHandlerAndTest(t, &hc, StatusCritical, testVersion, testStartTime, checks)
 	})
 	Convey("Given an unhealthy app and an app that has just turned critical and is under the critical threshold", t, func() {
 		statuses := []CheckState{unhealthyStatus, freshCriticalStatus}
 		hc := createHealthCheck(statuses, testStartTime, 10*time.Minute, true)
-		hc.TimeOfFirstCriticalError = testStartTime.Add(-1 * time.Minute)
+		hc.timeOfFirstCriticalError = testStartTime.Add(-1 * time.Minute)
 		runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, testStartTime, statuses)
 	})
 	Convey("Given an unhealthy app and an app that has been critical for longer than the critical threshold", t, func() {
 		statuses := []CheckState{unhealthyStatus, criticalStatus}
 		hc := createHealthCheck(statuses, testStartTime, 10*time.Minute, true)
-		hc.TimeOfFirstCriticalError = testStartTime.Add(-22 * time.Minute)
+		hc.timeOfFirstCriticalError = testStartTime.Add(-22 * time.Minute)
 		runHealthHandlerAndTest(t, &hc, StatusCritical, testVersion, testStartTime, statuses)
 	})
 	Convey("Given an app just started up", t, func() {
 		statuses := []CheckState{freshCriticalStatus}
 		justStartedTime := time.Now().UTC()
 		hc := createHealthCheck(statuses, justStartedTime, 10*time.Minute, false)
-		hc.TimeOfFirstCriticalError = justStartedTime
+		hc.timeOfFirstCriticalError = justStartedTime
 		runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, justStartedTime, nil)
 	})
 	Convey("Given an app has begun to start but not finished starting up completely", t, func() {
 		statuses := []CheckState{freshCriticalStatus}
 		justStartedTime := time.Now().UTC()
 		hc := createHealthCheck(statuses, justStartedTime, 10*time.Minute, true)
-		hc.TimeOfFirstCriticalError = justStartedTime
+		hc.timeOfFirstCriticalError = justStartedTime
 		runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, justStartedTime, statuses)
 	})
 	Convey("Given no apps", t, func() {
@@ -764,9 +764,9 @@ func TestHandlerMultipleChecks(t *testing.T) {
 			Checks:                   checks,
 			Version:                  testVersion,
 			StartTime:                testStartTime,
-			CriticalErrorTimeout:     10 * time.Minute,
-			TimeOfFirstCriticalError: testStartTime.Add(-30 * time.Minute),
-			Tickers:                  nil,
+			criticalErrorTimeout:     10 * time.Minute,
+			timeOfFirstCriticalError: testStartTime.Add(-30 * time.Minute),
+			tickers:                  nil,
 		}
 		runHealthHandlerAndTest(t, &hc, StatusOK, testVersion, testStartTime, statuses)
 	})
@@ -801,8 +801,8 @@ func createHealthCheck(statuses []CheckState, startTime time.Time, critErrTimeou
 		Checks:               createChecksSlice(statuses, hasPreviousCheck),
 		Version:              testVersion,
 		StartTime:            startTime,
-		CriticalErrorTimeout: critErrTimeout,
-		Tickers:              nil,
+		criticalErrorTimeout: critErrTimeout,
+		tickers:              nil,
 	}
 	return hc
 }

--- a/healthcheck/handler_test.go
+++ b/healthcheck/handler_test.go
@@ -22,12 +22,15 @@ var testVersion = VersionInfo{
 }
 
 func createATestCheck(stateToReturn CheckState, pretendHistory bool) *Check {
-	checkerFunc := func(ctx context.Context) (status *CheckState, err error) {
-		return &stateToReturn, nil
+	checkerFunc := func(ctx context.Context, state *CheckState) error {
+		if pretendHistory {
+			state = &stateToReturn
+		}
+		return nil
 	}
 	check, _ := newCheck(checkerFunc)
 	if pretendHistory {
-		check.State = &stateToReturn
+		check.state = &stateToReturn
 	}
 	return check
 }
@@ -81,7 +84,7 @@ func runHealthHandlerAndTest(t *testing.T, hc HealthCheck, desiredStatus string,
 
 	if statuses != nil {
 		for i, check := range healthCheck.Checks {
-			So(*check.State, ShouldResemble, statuses[i])
+			So(*check.state, ShouldResemble, statuses[i])
 		}
 	} else {
 

--- a/healthcheck/handler_test.go
+++ b/healthcheck/handler_test.go
@@ -35,14 +35,13 @@ func createATestCheck(stateToReturn CheckState, pretendHistory bool) *Check {
 	return check
 }
 
-func createHealthCheck(statuses []CheckState, startTime time.Time, critErrTimeout time.Duration, firstCritErr time.Time, pretendHistory bool) HealthCheck {
+func createHealthCheck(statuses []CheckState, startTime time.Time, critErrTimeout time.Duration, pretendHistory bool) HealthCheck {
 	hc := HealthCheck{
-		Checks:                   createChecksSlice(statuses, pretendHistory),
-		Version:                  testVersion,
-		StartTime:                startTime,
-		CriticalErrorTimeout:     critErrTimeout,
-		TimeOfFirstCriticalError: firstCritErr,
-		Tickers:                  nil,
+		Checks:               createChecksSlice(statuses, pretendHistory),
+		Version:              testVersion,
+		StartTime:            startTime,
+		CriticalErrorTimeout: critErrTimeout,
+		Tickers:              nil,
 	}
 	return hc
 }
@@ -55,7 +54,7 @@ func createChecksSlice(statuses []CheckState, pretendHistory bool) []*Check {
 	return checks
 }
 
-func runHealthHandlerAndTest(t *testing.T, hc HealthCheck, desiredStatus string, testVersion VersionInfo, testStartTime time.Time, statuses []CheckState) {
+func runHealthHandlerAndTest(t *testing.T, hc *HealthCheck, desiredStatus string, testVersion VersionInfo, testStartTime time.Time, statuses []CheckState) {
 	req, err := http.NewRequest("GET", "/health", nil)
 	if err != nil {
 		t.Fail()
@@ -91,7 +90,210 @@ func runHealthHandlerAndTest(t *testing.T, hc HealthCheck, desiredStatus string,
 	}
 }
 
-func TestHandler(t *testing.T) {
+func TestHandlerSignleCheck(t *testing.T) {
+	t0 := time.Now().UTC()
+	t10 := t0.Add(-10 * time.Minute) // 10 min ago
+	t20 := t0.Add(-20 * time.Minute) // 20 min ago
+	t30 := t0.Add(-30 * time.Minute) // 30 min ago
+	criticalErrTimeout := 11 * time.Minute
+
+	healthyStatus1 := CheckState{
+		Name:        "Some App 1",
+		Status:      StatusOK,
+		StatusCode:  http.StatusOK,
+		Message:     "App 1 is healthy",
+		LastChecked: &t0,
+		LastSuccess: &t0,
+		LastFailure: &t10,
+	}
+	unhealthyStatus := CheckState{
+		Name:        "Some App 2",
+		Status:      StatusWarning,
+		StatusCode:  http.StatusTooManyRequests,
+		Message:     "Something has been unhealthy for past 10 minutes",
+		LastChecked: &t0,
+		LastSuccess: &t10,
+		LastFailure: &t0,
+	}
+	freshCriticalStatus := CheckState{
+		Name:        "Some App 3",
+		Status:      StatusCritical,
+		StatusCode:  http.StatusInternalServerError,
+		Message:     "Something has been critical for the past 10 minutes",
+		LastChecked: &t0,
+		LastSuccess: &t10,
+		LastFailure: &t0,
+	}
+	oldCriticalStatus := CheckState{
+		Name:        "Some App 4",
+		Status:      StatusCritical,
+		StatusCode:  http.StatusInternalServerError,
+		Message:     "Something has been critical for the past 30 minutes",
+		LastChecked: &t0,
+		LastSuccess: &t30,
+		LastFailure: &t0,
+	}
+
+	nilStatus := CheckState{
+		Name: "Some App 5",
+	}
+	healthyNeverUnhealthyStatus := CheckState{
+		Name:        "Some App 6",
+		Status:      StatusOK,
+		StatusCode:  http.StatusOK,
+		Message:     "App 6 is healthy",
+		LastChecked: &t0,
+		LastSuccess: &t0,
+	}
+	unhealthyNeverHealthyStatus := CheckState{
+		Name:        "Some App 7",
+		Status:      StatusWarning,
+		StatusCode:  http.StatusTooManyRequests,
+		Message:     "Something is unhealthy",
+		LastChecked: &t0,
+		LastFailure: &t0,
+	}
+	criticalNeverHealthyStatus := CheckState{
+		Name:        "Some App 8",
+		Status:      StatusCritical,
+		StatusCode:  http.StatusTooManyRequests,
+		Message:     "Something is critical",
+		LastChecked: &t0,
+		LastFailure: &t0,
+	}
+
+	Convey("Given a healthcheck with no past failures or successes", t, func() {
+
+		hc := HealthCheck{
+			Version:              testVersion,
+			StartTime:            t0,
+			CriticalErrorTimeout: criticalErrTimeout,
+			Tickers:              nil,
+		}
+
+		Convey("An empty check should result in the app reporting back as warning", func() {
+			statuses := []CheckState{nilStatus}
+			hc.Checks = createChecksSlice(statuses, true)
+			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
+			// TimeOfFirstCriticalError not set
+			So(hc.TimeOfFirstCriticalError, ShouldResemble, time.Time{})
+		})
+		Convey("A healthy check that has never been unhealthy should result in the app reporting back as healthy", func() {
+			statuses := []CheckState{healthyNeverUnhealthyStatus}
+			hc.Checks = createChecksSlice(statuses, true)
+			runHealthHandlerAndTest(t, &hc, StatusOK, testVersion, t0, statuses)
+			// TimeOfFirstCriticalError not set
+			So(hc.TimeOfFirstCriticalError, ShouldResemble, time.Time{})
+		})
+		Convey("A healthy check that has been unhealthy in the past should result in the app reporting back as healthy", func() {
+			statuses := []CheckState{healthyStatus1}
+			hc.Checks = createChecksSlice(statuses, true)
+			runHealthHandlerAndTest(t, &hc, StatusOK, testVersion, t0, statuses)
+			// TimeOfFirstCriticalError not set
+			So(hc.TimeOfFirstCriticalError, ShouldResemble, time.Time{})
+		})
+		Convey("An unhealthy check that has never been healthy should result in the app reporting back as warning", func() {
+			statuses := []CheckState{unhealthyNeverHealthyStatus}
+			hc.Checks = createChecksSlice(statuses, true)
+			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
+			// TimeOfFirstCriticalError not set
+			So(hc.TimeOfFirstCriticalError, ShouldResemble, time.Time{})
+		})
+		Convey("An unhealthy check that has been healthy in the past should result in the app reporting back as warning", func() {
+			statuses := []CheckState{unhealthyStatus}
+			hc.Checks = createChecksSlice(statuses, true)
+			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
+			// TimeOfFirstCriticalError not set
+			So(hc.TimeOfFirstCriticalError, ShouldResemble, time.Time{})
+		})
+		Convey("A critical check that has never been healthy should result in the app reporting back as warning and updating timestamp for first critical error", func() {
+			statuses := []CheckState{criticalNeverHealthyStatus}
+			hc.Checks = createChecksSlice(statuses, true)
+			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
+			// TimeOfFirstCriticalError set to this check's failure time
+			So(hc.TimeOfFirstCriticalError, ShouldHappenWithin, time.Second, t0)
+		})
+		Convey("A critical check that has been healthy in the past should result in the app reporting back as warning and updating timestamp for first critical error", func() {
+			statuses := []CheckState{oldCriticalStatus}
+			hc.Checks = createChecksSlice(statuses, true)
+			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
+			// TimeOfFirstCriticalError set to this check's failure time
+			So(hc.TimeOfFirstCriticalError, ShouldHappenWithin, time.Second, t0)
+		})
+	})
+
+	Convey("Given a healthcheck with a recent past critical check (timeout not expired), and no success received since", t, func() {
+
+		hc := HealthCheck{
+			Version:                  testVersion,
+			StartTime:                t0,
+			CriticalErrorTimeout:     criticalErrTimeout,
+			TimeOfFirstCriticalError: t10,
+			Tickers:                  nil,
+		}
+
+		Convey("A healthy check should result in the app reporting back as healthy", func() {
+			statuses := []CheckState{healthyNeverUnhealthyStatus}
+			hc.Checks = createChecksSlice(statuses, true)
+			runHealthHandlerAndTest(t, &hc, StatusOK, testVersion, t0, statuses)
+			// TimeOfFirstCriticalError not updated
+			So(hc.TimeOfFirstCriticalError, ShouldResemble, t10)
+		})
+		Convey("A recent critical check happening before the timeout expires should result in the app reporting back as warning", func() {
+			statuses := []CheckState{freshCriticalStatus}
+			hc.Checks = createChecksSlice(statuses, true)
+			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
+			// TimeOfFirstCriticalError not updated
+			So(hc.TimeOfFirstCriticalError, ShouldResemble, t10)
+		})
+		Convey("A critical check that has been critical for longer than the timeout and the value of first critical error, "+
+			"should result in the app reporting back as warning and not updating timestamp for first critical error", func() {
+			statuses := []CheckState{oldCriticalStatus}
+			hc.Checks = createChecksSlice(statuses, true)
+			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
+			// TimeOfFirstCriticalError not updated
+			So(hc.TimeOfFirstCriticalError, ShouldResemble, t10)
+		})
+	})
+
+	Convey("Given a healthcheck with an old past critical check (timeout expired), and no success received since", t, func() {
+
+		hc := HealthCheck{
+			Version:                  testVersion,
+			StartTime:                t0,
+			CriticalErrorTimeout:     criticalErrTimeout,
+			TimeOfFirstCriticalError: t20,
+			Tickers:                  nil,
+		}
+
+		Convey("A healthy check should result in the app reporting back as healthy", func() {
+			statuses := []CheckState{healthyNeverUnhealthyStatus}
+			hc.Checks = createChecksSlice(statuses, true)
+			runHealthHandlerAndTest(t, &hc, StatusOK, testVersion, t0, statuses)
+			// TimeOfFirstCriticalError not set
+			So(hc.TimeOfFirstCriticalError, ShouldResemble, t20)
+		})
+		Convey("A recent critical check (last success more recent than first critical) should result in the app reporting back as warning "+
+			"and refresh timestamp for first critical error", func() {
+			statuses := []CheckState{freshCriticalStatus}
+			hc.Checks = createChecksSlice(statuses, true)
+			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
+			// TimeOfFirstCriticalError set to this check's failure time
+			So(hc.TimeOfFirstCriticalError, ShouldHappenWithin, time.Second, t0)
+		})
+		Convey("A critical check (last success older than first critical) should result in the app reporting back as critical "+
+			"and not refreshing timestamp for first critical error", func() {
+			statuses := []CheckState{oldCriticalStatus}
+			hc.Checks = createChecksSlice(statuses, true)
+			runHealthHandlerAndTest(t, &hc, StatusCritical, testVersion, t0, statuses)
+			// TimeOfFirstCriticalError set to this check's failure time
+			So(hc.TimeOfFirstCriticalError, ShouldResemble, t20)
+		})
+	})
+
+}
+
+func TestHandlerMultipleChecks(t *testing.T) {
 	testStartTime := time.Now().UTC().Add(-20 * time.Minute)
 	priorTestTime := testStartTime.Add(-30 * time.Minute)
 	healthyStatus1 := CheckState{
@@ -150,40 +352,47 @@ func TestHandler(t *testing.T) {
 
 	Convey("Given a complete Healthy set of checks the app should report back as healthy", t, func() {
 		statuses := []CheckState{healthyStatus1, healthyStatus2, healthyStatus3}
-		hc := createHealthCheck(statuses, testStartTime, 10*time.Minute, testStartTime.Add(-30*time.Minute), true)
-		runHealthHandlerAndTest(t, hc, StatusOK, testVersion, testStartTime, statuses)
+		hc := createHealthCheck(statuses, testStartTime, 10*time.Minute, true)
+		hc.TimeOfFirstCriticalError = testStartTime.Add(-30 * time.Minute)
+		runHealthHandlerAndTest(t, &hc, StatusOK, testVersion, testStartTime, statuses)
 	})
 	Convey("Given a healthy app and an unhealthy app", t, func() {
 		statuses := []CheckState{healthyStatus1, unhealthyStatus}
-		hc := createHealthCheck(statuses, testStartTime, 15*time.Second, testStartTime.Add(-30*time.Minute), true)
-		runHealthHandlerAndTest(t, hc, StatusWarning, testVersion, testStartTime, statuses)
+		hc := createHealthCheck(statuses, testStartTime, 15*time.Second, true)
+		hc.TimeOfFirstCriticalError = testStartTime.Add(-30 * time.Minute)
+		runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, testStartTime, statuses)
 	})
 	Convey("Given a healthy app and a critical app that is beyond the threshold", t, func() {
 		checks := []CheckState{healthyStatus1, criticalStatus}
-		hc := createHealthCheck(checks, testStartTime, 10*time.Minute, testStartTime.Add(-22*time.Minute), true)
-		runHealthHandlerAndTest(t, hc, StatusCritical, testVersion, testStartTime, checks)
+		hc := createHealthCheck(checks, testStartTime, 10*time.Minute, true)
+		hc.TimeOfFirstCriticalError = testStartTime.Add(-22 * time.Minute)
+		runHealthHandlerAndTest(t, &hc, StatusCritical, testVersion, testStartTime, checks)
 	})
 	Convey("Given an unhealthy app and an app that has just turned critical and is under the critical threshold", t, func() {
 		statuses := []CheckState{unhealthyStatus, freshCriticalStatus}
-		hc := createHealthCheck(statuses, testStartTime, 10*time.Minute, time.Now().Add(-1*time.Minute), true)
-		runHealthHandlerAndTest(t, hc, StatusWarning, testVersion, testStartTime, statuses)
+		hc := createHealthCheck(statuses, testStartTime, 10*time.Minute, true)
+		hc.TimeOfFirstCriticalError = testStartTime.Add(-1 * time.Minute)
+		runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, testStartTime, statuses)
 	})
 	Convey("Given an unhealthy app and an app that has been critical for longer than the critical threshold", t, func() {
 		statuses := []CheckState{unhealthyStatus, criticalStatus}
-		hc := createHealthCheck(statuses, testStartTime, 10*time.Minute, testStartTime.Add(-22*time.Minute), true)
-		runHealthHandlerAndTest(t, hc, StatusCritical, testVersion, testStartTime, statuses)
+		hc := createHealthCheck(statuses, testStartTime, 10*time.Minute, true)
+		hc.TimeOfFirstCriticalError = testStartTime.Add(-22 * time.Minute)
+		runHealthHandlerAndTest(t, &hc, StatusCritical, testVersion, testStartTime, statuses)
 	})
 	Convey("Given an app just started up", t, func() {
 		statuses := []CheckState{freshCriticalStatus}
 		justStartedTime := time.Now().UTC()
-		hc := createHealthCheck(statuses, justStartedTime, 10*time.Minute, justStartedTime, false)
-		runHealthHandlerAndTest(t, hc, StatusWarning, testVersion, justStartedTime, nil)
+		hc := createHealthCheck(statuses, justStartedTime, 10*time.Minute, false)
+		hc.TimeOfFirstCriticalError = justStartedTime
+		runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, justStartedTime, nil)
 	})
 	Convey("Given an app has begun to start but not finished starting up completely", t, func() {
 		statuses := []CheckState{freshCriticalStatus}
 		justStartedTime := time.Now().UTC()
-		hc := createHealthCheck(statuses, justStartedTime, 10*time.Minute, justStartedTime, true)
-		runHealthHandlerAndTest(t, hc, StatusWarning, testVersion, justStartedTime, statuses)
+		hc := createHealthCheck(statuses, justStartedTime, 10*time.Minute, true)
+		hc.TimeOfFirstCriticalError = justStartedTime
+		runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, justStartedTime, statuses)
 	})
 	Convey("Given no apps", t, func() {
 		var checks []*Check
@@ -196,6 +405,6 @@ func TestHandler(t *testing.T) {
 			TimeOfFirstCriticalError: testStartTime.Add(-30 * time.Minute),
 			Tickers:                  nil,
 		}
-		runHealthHandlerAndTest(t, hc, StatusOK, testVersion, testStartTime, statuses)
+		runHealthHandlerAndTest(t, &hc, StatusOK, testVersion, testStartTime, statuses)
 	})
 }

--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -37,7 +37,7 @@ type VersionInfo struct {
 // criticalTimeout for how long to wait until an unhealthy dependent propagates its state to make this app unhealthy
 // interval in which to check health of dependencies
 // checkers which implement the checker interface and can run a checkup to determine the health of the app and/or its dependencies
-func Create(version VersionInfo, criticalTimeout, interval time.Duration, checkers ...*Checker) HealthCheck {
+func Create(version VersionInfo, criticalTimeout, interval time.Duration, checkers ...Checker) HealthCheck {
 
 	var checks []*Check
 
@@ -71,7 +71,7 @@ func CreateVersionInfo(buildTime time.Time, gitCommit, version string) VersionIn
 }
 
 // AddCheck adds a provided checker to the health check
-func (hc *HealthCheck) AddCheck(checker *Checker) (err error) {
+func (hc *HealthCheck) AddCheck(checker Checker) (err error) {
 	if hc.Started {
 		err := errors.New("unable to add new check, health check has already started")
 		return err

--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -37,30 +37,21 @@ type VersionInfo struct {
 // version information of the app,
 // criticalTimeout for how long to wait until an unhealthy dependent propagates its state to make this app unhealthy
 // interval in which to check health of dependencies
-// checkers which implement the checker interface and can run a checkup to determine the health of the app and/or its dependencies
-func New(version VersionInfo, criticalTimeout, interval time.Duration, checkers ...Checker) (HealthCheck, error) {
-	hc := HealthCheck{
+func New(version VersionInfo, criticalTimeout, interval time.Duration) HealthCheck {
+	return HealthCheck{
 		Checks:               []*Check{},
 		Version:              version,
 		criticalErrorTimeout: criticalTimeout,
 		interval:             interval,
 		tickers:              []*ticker{},
 	}
-
-	for _, checker := range checkers {
-		if err := hc.AddCheck(checker); err != nil {
-			return hc, err
-		}
-	}
-
-	return hc, nil
 }
 
-// CreateVersionInfo returns a health check version info object. Caller to provide:
+// NewVersionInfo returns a health check version info object. Caller to provide:
 // buildTime for when the app was built as a unix time stamp in string form
 // gitCommit the SHA-1 commit hash of the built app
 // version the semantic version of the built app
-func CreateVersionInfo(buildTime, gitCommit, version string) (VersionInfo, error) {
+func NewVersionInfo(buildTime, gitCommit, version string) (VersionInfo, error) {
 	versionInfo := VersionInfo{
 		BuildTime:       time.Unix(0, 0),
 		GitCommit:       gitCommit,
@@ -78,8 +69,8 @@ func CreateVersionInfo(buildTime, gitCommit, version string) (VersionInfo, error
 }
 
 // AddCheck adds a provided checker to the health check
-func (hc *HealthCheck) AddCheck(checker Checker) (err error) {
-	check, err := NewCheck(checker)
+func (hc *HealthCheck) AddCheck(name string, checker Checker) (err error) {
+	check, err := NewCheck(name, checker)
 	if err != nil {
 		return err
 	}

--- a/healthcheck/healthcheck_test.go
+++ b/healthcheck/healthcheck_test.go
@@ -348,20 +348,40 @@ func TestAddCheck(t *testing.T) {
 
 func TestCreateVersionInfo(t *testing.T) {
 	Convey("Create a new versionInfo object", t, func() {
-		buildTime := time.Unix(0, 0)
+		buildTime := "0"
 		gitCommit := "d6cd1e2bd19e03a81132a23b2025920577f84e37"
 		version := "1.0.0"
 
 		expectedVersion := VersionInfo{
-			BuildTime:       buildTime,
+			BuildTime:       time.Unix(0, 0),
 			GitCommit:       gitCommit,
 			Language:        language,
 			LanguageVersion: runtime.Version(),
 			Version:         version,
 		}
 
-		outputVersion := CreateVersionInfo(buildTime, gitCommit, version)
+		outputVersion, err := CreateVersionInfo(buildTime, gitCommit, version)
 
+		So(err, ShouldBeNil)
+		So(outputVersion, ShouldResemble, expectedVersion)
+	})
+
+	Convey("Create a new versionInfo object passing an invalid build time", t, func() {
+		buildTime := "some invalid date"
+		gitCommit := "d6cd1e2bd19e03a81132a23b2025920577f84e37"
+		version := "1.0.0"
+
+		expectedVersion := VersionInfo{
+			BuildTime:       time.Unix(0, 0),
+			GitCommit:       gitCommit,
+			Language:        language,
+			LanguageVersion: runtime.Version(),
+			Version:         version,
+		}
+
+		outputVersion, err := CreateVersionInfo(buildTime, gitCommit, version)
+
+		So(err, ShouldNotBeNil)
 		So(outputVersion, ShouldResemble, expectedVersion)
 	})
 }

--- a/healthcheck/healthcheck_test.go
+++ b/healthcheck/healthcheck_test.go
@@ -24,10 +24,10 @@ var version = VersionInfo{
 }
 
 func generateTestState(msg string) CheckState {
-	previousTime := time.Unix(0,0).UTC()
+	previousTime := time.Unix(0, 0).UTC()
 	currentTime := previousTime.Add(time.Duration(30) * time.Minute)
 	return CheckState{
-		name: "some check",
+		name:        "some check",
 		status:      StatusOK,
 		statusCode:  200,
 		message:     msg,
@@ -37,7 +37,7 @@ func generateTestState(msg string) CheckState {
 	}
 }
 
-func TestCreate(t *testing.T) {
+func TestNew(t *testing.T) {
 	checkFunc := func(ctx context.Context, state *CheckState) error {
 		now := time.Now().UTC()
 		state.mutex.Lock()
@@ -56,7 +56,7 @@ func TestCreate(t *testing.T) {
 	Convey("Create a new Health Check given one good working check function to run with status code", t, func() {
 		ctx := context.Background()
 		timeBeforeCreation := time.Now().UTC()
-		hc, err := Create(version, criticalTimeout, interval, checkFunc)
+		hc, err := New(version, criticalTimeout, interval, checkFunc)
 		hc.Start(ctx)
 		defer hc.Stop()
 
@@ -82,7 +82,7 @@ func TestCreate(t *testing.T) {
 	Convey("Create a new Health Check given two good working check functions to run", t, func() {
 		ctx := context.Background()
 		timeBeforeCreation := time.Now().UTC()
-		hc, err := Create(version, criticalTimeout, interval, checkFunc, checkFunc)
+		hc, err := New(version, criticalTimeout, interval, checkFunc, checkFunc)
 		hc.Start(ctx)
 		defer hc.Stop()
 
@@ -113,7 +113,7 @@ func TestCreate(t *testing.T) {
 	Convey("Create a new Health Check without giving any check functions", t, func() {
 		ctx := context.Background()
 		timeBeforeCreation := time.Now().UTC()
-		hc, err := Create(version, criticalTimeout, interval)
+		hc, err := New(version, criticalTimeout, interval)
 		hc.Start(ctx)
 		defer hc.Stop()
 
@@ -131,7 +131,7 @@ func TestCreate(t *testing.T) {
 
 	Convey("Create a new Health Check given a broken check function", t, func() {
 		ctx := context.Background()
-		hc, err := Create(version, criticalTimeout, interval, cfFail)
+		hc, err := New(version, criticalTimeout, interval, cfFail)
 		hc.Start(ctx)
 		defer hc.Stop()
 
@@ -149,14 +149,14 @@ func TestCreate(t *testing.T) {
 	})
 
 	Convey("Fail to create a new Health Check when given a nil check function", t, func() {
-		_, err := Create(version, criticalTimeout, interval, nil)
+		_, err := New(version, criticalTimeout, interval, nil)
 
 		So(err, ShouldNotBeNil)
 	})
 
 	Convey("Given a Health Check with a cancellable context", t, func() {
 		ctx, cancel := context.WithCancel(context.Background())
-		hc, err := Create(version, criticalTimeout, interval, cfFail)
+		hc, err := New(version, criticalTimeout, interval, cfFail)
 		hc.Start(ctx)
 		// no `defer hc.Stop()` because of `cancel()`
 
@@ -187,7 +187,7 @@ func TestCreate(t *testing.T) {
 		statusCode := 200
 
 		ctx := context.Background()
-		hc, err := Create(version, criticalTimeout, interval, cfFail)
+		hc, err := New(version, criticalTimeout, interval, cfFail)
 		hc.Checks[0].state.name = name
 		hc.Checks[0].state.status = status
 		hc.Checks[0].state.message = message
@@ -221,7 +221,7 @@ func TestAddCheck(t *testing.T) {
 
 	Convey("Given a Health Check without any registered checks", t, func() {
 		ctx := context.Background()
-		hc, err := Create(version, criticalTimeout, interval)
+		hc, err := New(version, criticalTimeout, interval)
 
 		So(err, ShouldBeNil)
 
@@ -239,7 +239,7 @@ func TestAddCheck(t *testing.T) {
 
 	Convey("Given a Health Check with 1 check registered at creation", t, func() {
 		ctx := context.Background()
-		hc, err := Create(version, criticalTimeout, interval, cf)
+		hc, err := New(version, criticalTimeout, interval, cf)
 
 		So(err, ShouldBeNil)
 
@@ -256,7 +256,7 @@ func TestAddCheck(t *testing.T) {
 	})
 
 	Convey("Given a Health Check with 1 check that is started", t, func() {
-		hc, err := Create(version, criticalTimeout, interval, cf)
+		hc, err := New(version, criticalTimeout, interval, cf)
 		hc.Start(context.Background())
 		defer hc.Stop()
 
@@ -267,14 +267,14 @@ func TestAddCheck(t *testing.T) {
 			time.Sleep(2 * interval)
 			Convey("Then the number of tickers should increase by one", func() {
 				So(err, ShouldBeNil)
-				So(len(hc.tickers), ShouldEqual, origNumberOftickers + 1)
+				So(len(hc.tickers), ShouldEqual, origNumberOftickers+1)
 			})
 		})
 	})
 
 	Convey("Given a Health Check without any registered checks", t, func() {
 		ctx := context.Background()
-		hc, err := Create(version, criticalTimeout, interval)
+		hc, err := New(version, criticalTimeout, interval)
 
 		So(err, ShouldBeNil)
 

--- a/healthcheck/healthcheck_test.go
+++ b/healthcheck/healthcheck_test.go
@@ -68,14 +68,14 @@ func TestCreate(t *testing.T) {
 		So(hc.Version.LanguageVersion, ShouldEqual, "1.12")
 		So(hc.Version.Version, ShouldEqual, "1.0.0")
 		So(hc.StartTime, ShouldHappenBetween, timeBeforeCreation, time.Now().UTC())
-		So(hc.CriticalErrorTimeout, ShouldEqual, criticalTimeout)
-		So(len(hc.Tickers), ShouldEqual, 1)
+		So(hc.criticalErrorTimeout, ShouldEqual, criticalTimeout)
+		So(len(hc.tickers), ShouldEqual, 1)
 		Convey("After check function should have run, ensure the check state has updated", func() {
 			time.Sleep(2 * interval)
 
-			hc.Tickers[0].check.state.mutex.RLock()
-			So(*hc.Tickers[0].check.state.LastChecked(), ShouldHappenOnOrBetween, timeBeforeCreation, time.Now().UTC())
-			hc.Tickers[0].check.state.mutex.RUnlock()
+			hc.tickers[0].check.state.mutex.RLock()
+			So(*hc.tickers[0].check.state.LastChecked(), ShouldHappenOnOrBetween, timeBeforeCreation, time.Now().UTC())
+			hc.tickers[0].check.state.mutex.RUnlock()
 		})
 	})
 
@@ -95,18 +95,18 @@ func TestCreate(t *testing.T) {
 		So(hc.Version.LanguageVersion, ShouldEqual, "1.12")
 		So(hc.Version.Version, ShouldEqual, "1.0.0")
 		So(hc.StartTime, ShouldHappenBetween, timeBeforeCreation, time.Now().UTC())
-		So(hc.CriticalErrorTimeout, ShouldEqual, criticalTimeout)
-		So(len(hc.Tickers), ShouldEqual, 2)
+		So(hc.criticalErrorTimeout, ShouldEqual, criticalTimeout)
+		So(len(hc.tickers), ShouldEqual, 2)
 		Convey("After the check functions should have run, ensure both check states have updated", func() {
 			time.Sleep(2 * interval)
 
-			hc.Tickers[0].check.state.mutex.RLock()
-			So(*hc.Tickers[0].check.state.LastChecked(), ShouldHappenOnOrBetween, timeBeforeCreation, time.Now().UTC())
-			hc.Tickers[0].check.state.mutex.RUnlock()
+			hc.tickers[0].check.state.mutex.RLock()
+			So(*hc.tickers[0].check.state.LastChecked(), ShouldHappenOnOrBetween, timeBeforeCreation, time.Now().UTC())
+			hc.tickers[0].check.state.mutex.RUnlock()
 
-			hc.Tickers[1].check.state.mutex.RLock()
-			So(*hc.Tickers[1].check.state.LastChecked(), ShouldHappenOnOrBetween, timeBeforeCreation, time.Now().UTC())
-			hc.Tickers[1].check.state.mutex.RUnlock()
+			hc.tickers[1].check.state.mutex.RLock()
+			So(*hc.tickers[1].check.state.LastChecked(), ShouldHappenOnOrBetween, timeBeforeCreation, time.Now().UTC())
+			hc.tickers[1].check.state.mutex.RUnlock()
 		})
 	})
 
@@ -124,9 +124,9 @@ func TestCreate(t *testing.T) {
 		So(hc.Version.LanguageVersion, ShouldEqual, "1.12")
 		So(hc.Version.Version, ShouldEqual, "1.0.0")
 		So(hc.StartTime, ShouldHappenBetween, timeBeforeCreation, time.Now().UTC())
-		So(hc.CriticalErrorTimeout, ShouldEqual, criticalTimeout)
+		So(hc.criticalErrorTimeout, ShouldEqual, criticalTimeout)
 		So(len(hc.Checks), ShouldEqual, 0)
-		So(len(hc.Tickers), ShouldEqual, 0)
+		So(len(hc.tickers), ShouldEqual, 0)
 	})
 
 	Convey("Create a new Health Check given a broken check function", t, func() {
@@ -139,9 +139,9 @@ func TestCreate(t *testing.T) {
 		Convey("After check function has run, ensure it has correctly stored the results", func() {
 			time.Sleep(2 * interval)
 
-			hc.Tickers[0].check.state.mutex.RLock()
-			s := *hc.Tickers[0].check.state
-			hc.Tickers[0].check.state.mutex.RUnlock()
+			hc.tickers[0].check.state.mutex.RLock()
+			s := *hc.tickers[0].check.state
+			hc.tickers[0].check.state.mutex.RUnlock()
 
 			s.mutex = nil
 			So(s, ShouldResemble, CheckState{})
@@ -161,20 +161,20 @@ func TestCreate(t *testing.T) {
 		// no `defer hc.Stop()` because of `cancel()`
 
 		So(err, ShouldBeNil)
-		So(hc.Started, ShouldBeTrue)
+		So(hc.context, ShouldNotBeNil)
 
 		Convey("When the check function has time to run, and the context is cancelled", func() {
 			time.Sleep(2 * interval)
 
-			So(len(hc.Tickers), ShouldEqual, 1)
-			So(hc.Tickers[0].check.state, ShouldPointTo, hc.Checks[0].state)
-			So(hc.Tickers[0].isStopping(), ShouldBeFalse)
+			So(len(hc.tickers), ShouldEqual, 1)
+			So(hc.tickers[0].check.state, ShouldPointTo, hc.Checks[0].state)
+			So(hc.tickers[0].isStopping(), ShouldBeFalse)
 
 			cancel()
 
 			Convey("Then the tickers are stopped/stopping", func() {
 				time.Sleep(2 * interval)
-				So(hc.Tickers[0].isStopping(), ShouldBeTrue)
+				So(hc.tickers[0].isStopping(), ShouldBeTrue)
 			})
 		})
 	})
@@ -209,7 +209,7 @@ func TestCreate(t *testing.T) {
 			So(hc.Checks[0].state.statusCode, ShouldEqual, statusCode)
 			So(hc.Checks[0].state.lastChecked, ShouldEqual, &now)
 			So(hc.Checks[0].state.lastSuccess, ShouldEqual, &now)
-			hc.Tickers[0].check.state.mutex.RUnlock()
+			hc.tickers[0].check.state.mutex.RUnlock()
 		})
 	})
 }
@@ -233,7 +233,7 @@ func TestAddCheck(t *testing.T) {
 			defer hc.Stop()
 
 			time.Sleep(2 * interval)
-			So(len(hc.Tickers), ShouldEqual, 1)
+			So(len(hc.tickers), ShouldEqual, 1)
 		})
 	})
 
@@ -251,7 +251,7 @@ func TestAddCheck(t *testing.T) {
 			defer hc.Stop()
 
 			time.Sleep(2 * interval)
-			So(len(hc.Tickers), ShouldEqual, 2)
+			So(len(hc.tickers), ShouldEqual, 2)
 		})
 	})
 
@@ -261,13 +261,13 @@ func TestAddCheck(t *testing.T) {
 		defer hc.Stop()
 
 		So(err, ShouldBeNil)
-		origNumberOfTickers := len(hc.Tickers)
-		Convey("When you add another check - too late", func() {
+		origNumberOftickers := len(hc.tickers)
+		Convey("When you add another check", func() {
 			err := hc.AddCheck(cf)
-			Convey("Then there should be no increase in the number of tickers", func() {
-				So(err, ShouldNotBeNil)
-				time.Sleep(2 * interval)
-				So(len(hc.Tickers), ShouldEqual, origNumberOfTickers)
+			time.Sleep(2 * interval)
+			Convey("Then the number of tickers should increase by one", func() {
+				So(err, ShouldBeNil)
+				So(len(hc.tickers), ShouldEqual, origNumberOftickers + 1)
 			})
 		})
 	})
@@ -286,7 +286,7 @@ func TestAddCheck(t *testing.T) {
 			defer hc.Stop()
 
 			time.Sleep(2 * interval)
-			So(len(hc.Tickers), ShouldEqual, 0)
+			So(len(hc.tickers), ShouldEqual, 0)
 		})
 	})
 }

--- a/healthcheck/ticker.go
+++ b/healthcheck/ticker.go
@@ -44,13 +44,11 @@ func (ticker *ticker) start(ctx context.Context) {
 
 // runCheck runs a checker function of the check associated with the ticker
 func (ticker *ticker) runCheck(ctx context.Context) {
-	ticker.check.mutex.Lock()
-	defer ticker.check.mutex.Unlock()
 	err := ticker.check.checker(ctx, ticker.check.state)
 	if err != nil {
 		name := "no check has been made yet"
 		if ticker.check.state != nil {
-			name = ticker.check.state.Name
+			name = ticker.check.state.Name()
 		}
 		log.Event(nil, "failed", log.Error(err), log.Data{"external_service": name})
 		return

--- a/healthcheck/ticker.go
+++ b/healthcheck/ticker.go
@@ -44,19 +44,17 @@ func (ticker *ticker) start(ctx context.Context) {
 
 // runCheck runs a checker function of the check associated with the ticker
 func (ticker *ticker) runCheck(ctx context.Context) {
-	checkResults, err := ticker.check.Checker(ctx)
+	ticker.check.mutex.Lock()
+	defer ticker.check.mutex.Unlock()
+	err := ticker.check.checker(ctx, ticker.check.state)
 	if err != nil {
 		name := "no check has been made yet"
-		if ticker.check.State != nil {
-			name = ticker.check.State.Name
+		if ticker.check.state != nil {
+			name = ticker.check.state.Name
 		}
 		log.Event(nil, "failed", log.Error(err), log.Data{"external_service": name})
 		return
 	}
-
-	ticker.check.mutex.Lock()
-	defer ticker.check.mutex.Unlock()
-	ticker.check.State = checkResults
 }
 
 // stop the ticker

--- a/healthcheck/ticker.go
+++ b/healthcheck/ticker.go
@@ -44,8 +44,7 @@ func (ticker *ticker) start(ctx context.Context) {
 
 // runCheck runs a checker function of the check associated with the ticker
 func (ticker *ticker) runCheck(ctx context.Context) {
-	checkerFunc := *ticker.check.Checker
-	checkResults, err := checkerFunc(ctx)
+	checkResults, err := ticker.check.Checker(ctx)
 	if err != nil {
 		name := "no check has been made yet"
 		if ticker.check.State != nil {


### PR DESCRIPTION
### What

Polish some of the usage rough edges found during first use:
* Remove need to cast the Checker functions when passing them to `Create` or `AddCheck`
* Parse the unix timestamp string for build time when instantiating the version info so that this doesn't have to be done in the main of every app.  The build time is always a string due to being set using the ldflags during compilation.
* Fix missed error handling for case where a nil checker function is passed to Create
* Move responsibility for keeping the current check state from the Checker implementation into the health check library as we were needing to store it anyway.  This should simplify the implementation of individual checkers.
* Update README with examples of the current implementation and add an example implementation of a Checker
* Protect CheckState from misuse while also simplifying `Checker` type functions by making fields unexported and providing an `Update()` function to handle changes.
* Reduce the amount of lock blocking happening between the checks being run and the handler being called through use of the new `Update()` function and getters for the `CheckState`
* Allow adding of checks after `Start`

This PR includes changes from https://github.com/ONSdigital/dp-healthcheck/pull/11 that have already been reviewed.

### Who can review

Anyone but me.