### PR TITLE
Protect CheckState from misuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Adding a health check to an app
 
         ...
 
+        // Likely these values would come from your app's config
+        criticalTimeout := time.Minute
+        interval := 10 * time.Second
+
+        ...
+
         versionInfo := health.CreateVersionInfo(
             BuildTime,
             GitCommit,
@@ -212,35 +218,25 @@ Implement a checker by creating a function (with or without a receiver) that is 
 For example:
 
 ```
+
+const checkName = "check name"
+
 func Check(ctx context.Context, state *CheckState) error {
-	now := time.Now()
-
-	if state.Name == "" {
-		state.Name = "check name"
-	}
-
 	success := rand.Float32() < 0.5
 	warn := rand.Float32() < 0.5
 
 	if success {
-		state.Status = health.StatusOK
-		state.Message = "I'm OK"
-		state.LastSuccess = &now
+        state.Update(checkName, health.StatusOK, "I'm OK", 200)
 	} else if warn {
-		state.Status = health.StatusWarning
-		state.Message = "degraded function of ..."
-		state.LastFailure = &now
+        state.Update(checkName, health.StatusWarning, "degraded function of ...", 0)
 	} else {
-		state.Status = health.StatusCritical
-		state.Message = "failed to ..."
-		state.LastFailure = &now
+        state.Update(checkName, health.StatusWarning, "failed to ...", 503)
 	}
-	state.LastChecked = &now
 	return nil
 }
 ```
 
-Note that the `StatusCode` field is optional and only used for HTTP based checks.
+Note that the `statusCode` argument (last argument) to `CheckState.Update()` is only used for HTTP based checks.  If you do not have a status code then pass `0` as seen in the example above (degraded state/warning block).
 
 ### Contributing
 

--- a/healthcheck/check.go
+++ b/healthcheck/check.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"sync"
 	"time"
+	"fmt"
 )
 
 // A list of possible check statuses
@@ -20,6 +21,18 @@ type Checker func(context.Context, *CheckState) error
 
 // CheckState represents the health status returned by a checker
 type CheckState struct {
+	name        string
+	status      string
+	statusCode  int
+	message     string
+	lastChecked *time.Time
+	lastSuccess *time.Time
+	lastFailure *time.Time
+	mutex       *sync.RWMutex
+}
+
+// checkStateJSON represents the health status struct for use with json marshal/unmarshal (to deal with unexported fields)
+type checkStateJSON struct {
 	Name        string     `json:"name"`
 	Status      string     `json:"status"`
 	StatusCode  int        `json:"status_code,omitempty"`
@@ -33,15 +46,114 @@ type CheckState struct {
 type Check struct {
 	state   *CheckState
 	checker Checker
-	mutex   *sync.Mutex
+}
+
+// Name gets the check name
+func (s *CheckState) Name() string {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	return s.name
+}
+
+// Status gets the check status
+func (s *CheckState) Status() string {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	return s.status
+}
+
+// StatusCode gets the check status code
+func (s *CheckState) StatusCode() int {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	return s.statusCode
+}
+
+// Message gets the check message
+func (s *CheckState) Message() string {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	return s.message
+}
+
+// LastChecked gets the last checked time of the check
+func (s *CheckState) LastChecked() *time.Time {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	if s.lastChecked == nil {
+		return nil
+	}
+
+	t := *s.lastChecked
+	return &t
+}
+
+// LastSuccess gets the time of the last successful check
+func (s *CheckState) LastSuccess() *time.Time {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	if s.lastSuccess == nil {
+		return nil
+	}
+
+	t := *s.lastSuccess
+	return &t
+}
+
+// LastFailure gets the time of the last failed check
+func (s *CheckState) LastFailure() *time.Time {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	if s.lastFailure == nil {
+		return nil
+	}
+
+	t := *s.lastFailure
+	return &t
+}
+
+// Update updates the relavent state fields based on the status provided
+// name of the check
+// status of the check, must be one of healthcheck.StatusOK, healthcheck.StatusWarning or healthcheck.StatusCritical
+// message briefly describing the check state
+// statusCode returned if the check was an HTTP check (optional, provide 0 if not relevant)
+func (s *CheckState) Update(name, status, message string, statusCode int) error {
+	now := time.Now().UTC()
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	switch status {
+	case StatusOK:
+		s.lastSuccess = &now
+	case StatusWarning, StatusCritical:
+		s.lastFailure = &now
+	default:
+		return fmt.Errorf("invalid check status, must be one of %s, %s or %s", StatusOK, StatusWarning, StatusCritical)
+	}
+
+	s.status = status
+	s.message = message
+	s.statusCode = statusCode
+	s.lastChecked = &now
+
+	if s.name == "" {
+		s.name = name
+	}
+
+	return nil
 }
 
 // hasRun returns true if the check has been run and has state
 func (c *Check) hasRun() bool {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	if c.state.LastChecked == nil {
+	if c.state.LastChecked() == nil {
 		return false
 	}
 	return true
@@ -55,26 +167,55 @@ func newCheck(checker Checker) (*Check, error) {
 	}
 
 	return &Check{
-		state:   &CheckState{},
+		state: &CheckState{
+			mutex: &sync.RWMutex{},
+		},
 		checker: checker,
-		mutex:   &sync.Mutex{},
 	}, nil
 }
 
 func (c *Check) MarshalJSON() ([]byte, error) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
+	return json.Marshal(c.state)
+}
 
-	b, err := json.Marshal(c.state)
-	if err != nil {
-		return nil, err
-	}
-	return b, nil
+func (s *CheckState) MarshalJSON() ([]byte, error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	return json.Marshal(checkStateJSON{
+		Name:        s.name,
+		Status:      s.status,
+		StatusCode:  s.statusCode,
+		Message:     s.message,
+		LastChecked: s.lastChecked,
+		LastSuccess: s.lastSuccess,
+		LastFailure: s.lastFailure,
+	})
 }
 
 func (c *Check) UnmarshalJSON(b []byte) error {
-	if err := json.Unmarshal(b, &c.state); err != nil {
-		return err
+	if c.state == nil {
+		c.state = &CheckState{
+			mutex: &sync.RWMutex{},
+		}
 	}
-	return nil
+	return json.Unmarshal(b, c.state)
+}
+
+func (s *CheckState) UnmarshalJSON(b []byte) error {
+	temp := &checkStateJSON{}
+	err := json.Unmarshal(b, temp)
+	if err == nil {
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
+
+		s.name = temp.Name
+		s.status = temp.Status
+		s.statusCode = temp.StatusCode
+		s.message = temp.Message
+		s.lastChecked = temp.LastChecked
+		s.lastSuccess = temp.LastSuccess
+		s.lastFailure = temp.LastFailure
+	}
+	return err
 }

--- a/healthcheck/check_test.go
+++ b/healthcheck/check_test.go
@@ -2,7 +2,10 @@ package healthcheck
 
 import (
 	"context"
+	"encoding/json"
+	"sync"
 	"testing"
+	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -19,18 +22,320 @@ func TestCreateNew(t *testing.T) {
 		check, _ = newCheck(checkerFunc)
 		So(err, ShouldBeNil)
 		So(check.checker, ShouldEqual, checkerFunc)
-		So(check.mutex, ShouldNotBeNil)
-		So(check.state, ShouldResemble, &CheckState{})
+		So(check.state.mutex, ShouldNotBeNil)
+		So(check.state.name, ShouldEqual, "")
+		So(check.state.status, ShouldEqual, "")
+		So(check.state.statusCode, ShouldEqual, 0)
+		So(check.state.message, ShouldEqual, "")
+		So(check.state.lastChecked, ShouldBeNil)
+		So(check.state.lastSuccess, ShouldBeNil)
+		So(check.state.lastFailure, ShouldBeNil)
 	})
 	Convey("A second new check shares the right values", t, func() {
 		check2, err := newCheck(checkerFunc)
 		So(err, ShouldBeNil)
 		So(check2.checker, ShouldEqual, check.checker)
-		So(check2.mutex, ShouldNotPointTo, check.mutex)
+		So(check2.state.mutex, ShouldNotPointTo, check.state.mutex)
 	})
 	Convey("Fail to create a new check as checker given is nil", t, func() {
 		check3, err := newCheck(nil)
 		So(check3, ShouldBeNil)
 		So(err, ShouldNotBeNil)
+	})
+}
+
+func TestUpdate(t *testing.T) {
+	var (
+		checkName   = "check name"
+		okMessage   = "I'm OK"
+		failMessage = "failed to ..."
+	)
+
+	Convey("Given a new check state", t, func() {
+		before := time.Now().UTC()
+
+		state := &CheckState{
+			mutex: &sync.RWMutex{},
+		}
+
+		Convey("When the state is updated with OK status", func() {
+			err := state.Update(checkName, StatusOK, okMessage, 200)
+			So(err, ShouldBeNil)
+
+			Convey("Then the check state should be set accordingly", func() {
+				after := time.Now().UTC()
+
+				So(state.name, ShouldEqual, checkName)
+				So(state.status, ShouldEqual, StatusOK)
+				So(state.message, ShouldEqual, okMessage)
+				So(state.statusCode, ShouldEqual, 200)
+				So(*state.lastChecked, ShouldHappenOnOrBetween, before, after)
+				So(*state.lastSuccess, ShouldHappenOnOrBetween, before, after)
+			})
+		})
+	})
+
+	Convey("Given a new check state", t, func() {
+		before := time.Now().UTC()
+
+		state := &CheckState{
+			mutex: &sync.RWMutex{},
+		}
+
+		Convey("When the state is updated with warning status", func() {
+			err := state.Update(checkName, StatusWarning, failMessage, 200)
+			So(err, ShouldBeNil)
+
+			Convey("Then the check state should be set accordingly", func() {
+				after := time.Now().UTC()
+
+				So(state.name, ShouldEqual, checkName)
+				So(state.status, ShouldEqual, StatusWarning)
+				So(state.message, ShouldEqual, failMessage)
+				So(state.statusCode, ShouldEqual, 200)
+				So(*state.lastChecked, ShouldHappenOnOrBetween, before, after)
+				So(*state.lastFailure, ShouldHappenOnOrBetween, before, after)
+			})
+		})
+	})
+
+	Convey("Given a new check state with valid existing state", t, func() {
+		before := time.Now().UTC()
+
+		state := &CheckState{
+			mutex: &sync.RWMutex{},
+		}
+
+		Convey("When the state is updated with critical status", func() {
+			err := state.Update(checkName, StatusCritical, failMessage, 502)
+			So(err, ShouldBeNil)
+
+			Convey("Then the check state should be set accordingly", func() {
+				after := time.Now().UTC()
+
+				So(state.name, ShouldEqual, checkName)
+				So(state.status, ShouldEqual, StatusCritical)
+				So(state.message, ShouldEqual, failMessage)
+				So(state.statusCode, ShouldEqual, 502)
+				So(*state.lastChecked, ShouldHappenOnOrBetween, before, after)
+				So(*state.lastFailure, ShouldHappenOnOrBetween, before, after)
+			})
+		})
+	})
+
+	Convey("Given a new check state", t, func() {
+		before := time.Now().UTC()
+
+		state := &CheckState{
+			mutex: &sync.RWMutex{},
+		}
+		err := state.Update(checkName, StatusOK, okMessage, 200)
+		So(err, ShouldBeNil)
+
+		after := time.Now().UTC()
+
+		So(state.name, ShouldEqual, checkName)
+		So(state.status, ShouldEqual, StatusOK)
+		So(state.message, ShouldEqual, okMessage)
+		So(state.statusCode, ShouldEqual, 200)
+		So(*state.lastChecked, ShouldHappenOnOrBetween, before, after)
+		So(*state.lastSuccess, ShouldHappenOnOrBetween, before, after)
+
+		Convey("When the state is updated with another state", func() {
+			before2 := time.Now().UTC()
+			err := state.Update(checkName, StatusCritical, failMessage, 0)
+			So(err, ShouldBeNil)
+
+			Convey("Then then only the changed fields should overwitten", func() {
+				after2 := time.Now().UTC()
+
+				So(state.name, ShouldEqual, checkName)
+				So(state.status, ShouldEqual, StatusCritical)
+				So(state.message, ShouldEqual, failMessage)
+				So(state.statusCode, ShouldEqual, 0)
+				So(*state.lastChecked, ShouldHappenOnOrBetween, before2, after2)
+				So(*state.lastFailure, ShouldHappenOnOrBetween, before2, after2)
+				So(*state.lastSuccess, ShouldHappenOnOrBetween, before, after)
+			})
+		})
+	})
+
+	Convey("Given a new check state with valid existing state", t, func() {
+		state := &CheckState{
+			mutex: &sync.RWMutex{},
+		}
+
+		Convey("When the state is updated with an invalid status", func() {
+			err := state.Update(checkName, "some invalid status", failMessage, 502)
+
+			Convey("Then an error should be returned", func() {
+				So(err, ShouldNotBeNil)
+			})
+		})
+	})
+
+	Convey("Given a new check state with an existing name", t, func() {
+		state := &CheckState{
+			name:  checkName,
+			mutex: &sync.RWMutex{},
+		}
+		So(state.name, ShouldEqual, checkName)
+
+		Convey("When the state is updated", func() {
+			err := state.Update("a new name", StatusOK, okMessage, 0)
+			So(err, ShouldBeNil)
+
+			Convey("Then the name should not be changed", func() {
+				So(state.name, ShouldEqual, checkName)
+			})
+		})
+	})
+}
+
+func TestGets(t *testing.T) {
+	Convey("Given a populated check state", t, func() {
+		t0 := time.Unix(0, 0).UTC()
+		t1 := t0.Add(1 * time.Minute)
+		t2 := t0.Add(2 * time.Minute)
+		state := CheckState{
+			name:        "something",
+			status:      "OK",
+			message:     "this is a message",
+			statusCode:  200,
+			lastChecked: &t0,
+			lastSuccess: &t1,
+			lastFailure: &t2,
+			mutex: &sync.RWMutex{},
+		}
+
+		Convey("When getting the name", func() {
+			name := state.Name()
+
+			Convey("Then the correct name should be returned", func() {
+				So(name, ShouldEqual, state.name)
+			})
+		})
+
+		Convey("When getting the status", func() {
+			status := state.Status()
+
+			Convey("Then the correct status should be returned", func() {
+				So(status, ShouldEqual, state.status)
+			})
+		})
+
+		Convey("When getting the message", func() {
+			message := state.Message()
+
+			Convey("Then the correct message should be returned", func() {
+				So(message, ShouldEqual, state.message)
+			})
+		})
+
+		Convey("When getting the status code", func() {
+			statusCode := state.StatusCode()
+
+			Convey("Then the correct status code should be returned", func() {
+				So(statusCode, ShouldEqual, state.statusCode)
+			})
+		})
+
+		Convey("When getting the last checked time", func() {
+			lastChecked := state.LastChecked()
+
+			Convey("Then the correct time should be returned", func() {
+				So(lastChecked, ShouldResemble, state.lastChecked)
+			})
+		})
+
+		Convey("When getting the last success time", func() {
+			lastSuccess := state.LastSuccess()
+
+			Convey("Then the correct time should be returned", func() {
+				So(lastSuccess, ShouldResemble, state.lastSuccess)
+			})
+		})
+
+		Convey("When getting the last failure time", func() {
+			lastFailure := state.LastFailure()
+
+			Convey("Then the correct time should be returned", func() {
+				So(lastFailure, ShouldResemble, state.lastFailure)
+			})
+		})
+	})
+
+	Convey("Given an unpopulated check state", t, func() {
+		state := CheckState{
+			mutex: &sync.RWMutex{},
+		}
+
+		Convey("When getting the last checked time", func() {
+			lastChecked := state.LastChecked()
+
+			Convey("Then nil should be returned", func() {
+				So(lastChecked, ShouldBeNil)
+			})
+		})
+
+		Convey("When getting the last success time", func() {
+			lastSuccess := state.LastSuccess()
+
+			Convey("Then nil should be returned", func() {
+				So(lastSuccess, ShouldBeNil)
+			})
+		})
+
+		Convey("When getting the last failure time", func() {
+			lastFailure := state.LastFailure()
+
+			Convey("Then nil should be returned", func() {
+				So(lastFailure, ShouldBeNil)
+			})
+		})
+	})
+}
+
+func TestJSONMarshalling(t *testing.T) {
+	Convey("Given a new check with a populated state", t, func() {
+		t := time.Unix(0, 0).UTC()
+		checkerFunc := func(ctx context.Context, state *CheckState) error {
+			return nil
+		}
+		check, err := newCheck(checkerFunc)
+		check.state.name = "something"
+		check.state.status = "OK"
+		check.state.message = "this is a message"
+		check.state.statusCode = 200
+		check.state.lastChecked = &t
+		check.state.lastSuccess = &t
+		check.state.lastFailure = &t
+
+		So(err, ShouldBeNil)
+		Convey("When marshalling to json", func() {
+			j, err := json.Marshal(check)
+
+			Convey("Then the string form of the state should successful marshal", func() {
+				So(err, ShouldBeNil)
+				So(string(j), ShouldEqual, "{\"name\":\"something\",\"status\":\"OK\",\"status_code\":200,\"message\":\"this is a message\",\"last_checked\":\"1970-01-01T00:00:00Z\",\"last_success\":\"1970-01-01T00:00:00Z\",\"last_failure\":\"1970-01-01T00:00:00Z\"}")
+			})
+
+			Convey("When unmarshalling from json", func() {
+				check2, err := newCheck(checkerFunc)
+
+				So(err, ShouldBeNil)
+
+				err = json.Unmarshal(j, check2)
+
+				So(err, ShouldBeNil)
+				So(check2.state.name, ShouldEqual, check.state.name)
+				So(check2.state.status, ShouldEqual, check.state.status)
+				So(check2.state.statusCode, ShouldEqual, check.state.statusCode)
+				So(check2.state.message, ShouldEqual, check.state.message)
+				So(*check2.state.lastChecked, ShouldEqual, *check.state.lastChecked)
+				So(*check2.state.lastFailure, ShouldEqual, *check.state.lastFailure)
+				So(*check2.state.lastSuccess, ShouldEqual, *check.state.lastSuccess)
+			})
+		})
 	})
 }

--- a/healthcheck/handler.go
+++ b/healthcheck/handler.go
@@ -85,14 +85,14 @@ func (hc *HealthCheck) getCheckStatus(c *Check) string {
 
 		// Global state will be considered critical if check has been critical for longer
 		// than the first critical error since last success and the timeout has expired.
-		criticalTimeThreshold := hc.TimeOfFirstCriticalError.Add(hc.CriticalErrorTimeout)
-		if lastSuccess.Before(hc.TimeOfFirstCriticalError) && now.After(criticalTimeThreshold) {
+		criticalTimeThreshold := hc.timeOfFirstCriticalError.Add(hc.criticalErrorTimeout)
+		if lastSuccess.Before(hc.timeOfFirstCriticalError) && now.After(criticalTimeThreshold) {
 			status = StatusCritical
 		}
 
 		// Set timestamp of first critical error to now if there has been a success since the previous value, or if this is the first one.
-		if lastSuccess.After(hc.TimeOfFirstCriticalError) || hc.TimeOfFirstCriticalError.IsZero() {
-			hc.TimeOfFirstCriticalError = now
+		if lastSuccess.After(hc.timeOfFirstCriticalError) || hc.timeOfFirstCriticalError.IsZero() {
+			hc.timeOfFirstCriticalError = now
 		}
 
 		return status

--- a/healthcheck/handler.go
+++ b/healthcheck/handler.go
@@ -67,10 +67,7 @@ func (hc *HealthCheck) isAppHealthy() string {
 
 // getCheckStatus returns a string for the status on if an individual check
 func (hc *HealthCheck) getCheckStatus(c *Check) string {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	switch c.state.Status {
+	switch c.state.Status() {
 	case StatusOK:
 		return StatusOK
 	case StatusWarning:
@@ -81,9 +78,9 @@ func (hc *HealthCheck) getCheckStatus(c *Check) string {
 		status := StatusWarning
 
 		// last success or minTime if nil. c should not be muted.
-		lastSuccess := &minTime
-		if c.state.LastSuccess != nil {
-			lastSuccess = c.state.LastSuccess
+		lastSuccess := c.state.LastSuccess()
+		if lastSuccess == nil {
+			lastSuccess = &minTime
 		}
 
 		// Global state will be considered critical if check has been critical for longer

--- a/healthcheck/handler_test.go
+++ b/healthcheck/handler_test.go
@@ -34,8 +34,8 @@ func TestGetStatus(t *testing.T) {
 			hc := HealthCheck{
 				Version:              testVersion,
 				StartTime:            t0,
-				CriticalErrorTimeout: criticalErrTimeout,
-				Tickers:              nil,
+				criticalErrorTimeout: criticalErrTimeout,
+				tickers:              nil,
 			}
 
 			// Adding checks
@@ -53,8 +53,8 @@ func TestGetStatus(t *testing.T) {
 			hc := HealthCheck{
 				Version:              testVersion,
 				StartTime:            t0,
-				CriticalErrorTimeout: criticalErrTimeout,
-				Tickers:              nil,
+				criticalErrorTimeout: criticalErrTimeout,
+				tickers:              nil,
 			}
 
 			// Adding checks
@@ -78,8 +78,8 @@ func TestIsAppStartingUP(t *testing.T) {
 			hc := HealthCheck{
 				Version:              testVersion,
 				StartTime:            t0,
-				CriticalErrorTimeout: criticalErrTimeout,
-				Tickers:              nil,
+				criticalErrorTimeout: criticalErrTimeout,
+				tickers:              nil,
 			}
 
 			isStarting := hc.isAppStartingUp()
@@ -93,8 +93,8 @@ func TestIsAppStartingUP(t *testing.T) {
 			hc := HealthCheck{
 				Version:              testVersion,
 				StartTime:            t0,
-				CriticalErrorTimeout: criticalErrTimeout,
-				Tickers:              nil,
+				criticalErrorTimeout: criticalErrTimeout,
+				tickers:              nil,
 			}
 
 			// Adding checks
@@ -112,8 +112,8 @@ func TestIsAppStartingUP(t *testing.T) {
 			hc := HealthCheck{
 				Version:              testVersion,
 				StartTime:            t0,
-				CriticalErrorTimeout: criticalErrTimeout,
-				Tickers:              nil,
+				criticalErrorTimeout: criticalErrTimeout,
+				tickers:              nil,
 			}
 
 			// Adding checks
@@ -131,8 +131,8 @@ func TestIsAppStartingUP(t *testing.T) {
 			hc := HealthCheck{
 				Version:              testVersion,
 				StartTime:            t0,
-				CriticalErrorTimeout: criticalErrTimeout,
-				Tickers:              nil,
+				criticalErrorTimeout: criticalErrTimeout,
+				tickers:              nil,
 			}
 
 			// Adding checks
@@ -150,8 +150,8 @@ func TestIsAppStartingUP(t *testing.T) {
 			hc := HealthCheck{
 				Version:              testVersion,
 				StartTime:            t0,
-				CriticalErrorTimeout: criticalErrTimeout,
-				Tickers:              nil,
+				criticalErrorTimeout: criticalErrTimeout,
+				tickers:              nil,
 			}
 
 			// Adding checks
@@ -177,8 +177,8 @@ func TestGetCheckStatus(t *testing.T) {
 	hc := HealthCheck{
 		Version:              testVersion,
 		StartTime:            t0,
-		CriticalErrorTimeout: criticalErrTimeout,
-		Tickers:              nil,
+		criticalErrorTimeout: criticalErrTimeout,
+		tickers:              nil,
 	}
 
 	Convey("Given check status is okay return OK", t, func() {
@@ -216,11 +216,11 @@ func TestGetCheckStatus(t *testing.T) {
 					},
 				}
 
-				hc.TimeOfFirstCriticalError = t20
+				hc.timeOfFirstCriticalError = t20
 
 				status := hc.getCheckStatus(check)
 				So(status, ShouldEqual, StatusCritical)
-				So(hc.TimeOfFirstCriticalError, ShouldEqual, t20)
+				So(hc.timeOfFirstCriticalError, ShouldEqual, t20)
 			})
 		})
 
@@ -235,11 +235,11 @@ func TestGetCheckStatus(t *testing.T) {
 					},
 				}
 
-				hc.TimeOfFirstCriticalError = t10
+				hc.timeOfFirstCriticalError = t10
 
 				status := hc.getCheckStatus(check)
 				So(status, ShouldEqual, StatusCritical)
-				So(hc.TimeOfFirstCriticalError, ShouldEqual, t10)
+				So(hc.timeOfFirstCriticalError, ShouldEqual, t10)
 			})
 		})
 
@@ -253,11 +253,11 @@ func TestGetCheckStatus(t *testing.T) {
 					},
 				}
 
-				hc.TimeOfFirstCriticalError = t9
+				hc.timeOfFirstCriticalError = t9
 
 				status := hc.getCheckStatus(check)
 				So(status, ShouldEqual, StatusWarning)
-				So(hc.TimeOfFirstCriticalError, ShouldEqual, t9)
+				So(hc.timeOfFirstCriticalError, ShouldEqual, t9)
 				So(check.state.LastSuccess(), ShouldBeNil)
 			})
 		})
@@ -273,11 +273,11 @@ func TestGetCheckStatus(t *testing.T) {
 					},
 				}
 
-				hc.TimeOfFirstCriticalError = t10
+				hc.timeOfFirstCriticalError = t10
 
 				status := hc.getCheckStatus(check)
 				So(status, ShouldEqual, StatusWarning)
-				So(hc.TimeOfFirstCriticalError, ShouldHappenBetween, t0, time.Now().UTC())
+				So(hc.timeOfFirstCriticalError, ShouldHappenBetween, t0, time.Now().UTC())
 				So(check.state.LastSuccess(), ShouldResemble, &t9)
 			})
 		})
@@ -329,8 +329,8 @@ func TestIsAppHealthy(t *testing.T) {
 			hc := HealthCheck{
 				Version:              testVersion,
 				StartTime:            t0,
-				CriticalErrorTimeout: criticalErrTimeout,
-				Tickers:              nil,
+				criticalErrorTimeout: criticalErrTimeout,
+				tickers:              nil,
 			}
 
 			// Adding two healthy checks
@@ -350,8 +350,8 @@ func TestIsAppHealthy(t *testing.T) {
 			hc := HealthCheck{
 				Version:              testVersion,
 				StartTime:            t0,
-				CriticalErrorTimeout: criticalErrTimeout,
-				Tickers:              nil,
+				criticalErrorTimeout: criticalErrTimeout,
+				tickers:              nil,
 			}
 
 			// Adding two healthy checks
@@ -371,9 +371,9 @@ func TestIsAppHealthy(t *testing.T) {
 			hc := HealthCheck{
 				Version:                  testVersion,
 				StartTime:                t20,
-				CriticalErrorTimeout:     criticalErrTimeout,
-				Tickers:                  nil,
-				TimeOfFirstCriticalError: t1,
+				criticalErrorTimeout:     criticalErrTimeout,
+				tickers:                  nil,
+				timeOfFirstCriticalError: t1,
 			}
 
 			// Adding two healthy checks
@@ -393,9 +393,9 @@ func TestIsAppHealthy(t *testing.T) {
 			hc := HealthCheck{
 				Version:                  testVersion,
 				StartTime:                t20,
-				CriticalErrorTimeout:     criticalErrTimeout,
-				Tickers:                  nil,
-				TimeOfFirstCriticalError: t10,
+				criticalErrorTimeout:     criticalErrTimeout,
+				tickers:                  nil,
+				timeOfFirstCriticalError: t10,
 			}
 
 			// Adding two healthy checks
@@ -415,9 +415,9 @@ func TestIsAppHealthy(t *testing.T) {
 			hc := HealthCheck{
 				Version:                  testVersion,
 				StartTime:                t20,
-				CriticalErrorTimeout:     criticalErrTimeout,
-				Tickers:                  nil,
-				TimeOfFirstCriticalError: t1,
+				criticalErrorTimeout:     criticalErrTimeout,
+				tickers:                  nil,
+				timeOfFirstCriticalError: t1,
 			}
 
 			// Adding two healthy checks
@@ -437,9 +437,9 @@ func TestIsAppHealthy(t *testing.T) {
 			hc := HealthCheck{
 				Version:                  testVersion,
 				StartTime:                t20,
-				CriticalErrorTimeout:     criticalErrTimeout,
-				Tickers:                  nil,
-				TimeOfFirstCriticalError: t10,
+				criticalErrorTimeout:     criticalErrTimeout,
+				tickers:                  nil,
+				timeOfFirstCriticalError: t10,
 			}
 
 			// Adding two healthy checks
@@ -529,59 +529,59 @@ func TestHandlerSingleCheck(t *testing.T) {
 		hc := HealthCheck{
 			Version:              testVersion,
 			StartTime:            t0,
-			CriticalErrorTimeout: criticalErrTimeout,
-			Tickers:              nil,
+			criticalErrorTimeout: criticalErrTimeout,
+			tickers:              nil,
 		}
 
 		Convey("Then an empty check should result in the app reporting back as warning", func() {
 			statuses := []CheckState{nilStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError not set
-			So(hc.TimeOfFirstCriticalError, ShouldResemble, time.Time{})
+			// timeOfFirstCriticalError not set
+			So(hc.timeOfFirstCriticalError, ShouldResemble, time.Time{})
 		})
 
 		Convey("Then a healthy check that has never been unhealthy should result in the app reporting back as healthy", func() {
 			statuses := []CheckState{healthyNeverUnhealthyStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusOK, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError not set
-			So(hc.TimeOfFirstCriticalError, ShouldResemble, time.Time{})
+			// timeOfFirstCriticalError not set
+			So(hc.timeOfFirstCriticalError, ShouldResemble, time.Time{})
 		})
 		Convey("Then a healthy check that has been unhealthy in the past should result in the app reporting back as healthy", func() {
 			statuses := []CheckState{healthyStatus1}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusOK, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError not set
-			So(hc.TimeOfFirstCriticalError, ShouldResemble, time.Time{})
+			// timeOfFirstCriticalError not set
+			So(hc.timeOfFirstCriticalError, ShouldResemble, time.Time{})
 		})
 		Convey("Then an unhealthy check that has never been healthy should result in the app reporting back as warning", func() {
 			statuses := []CheckState{unhealthyNeverHealthyStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError not set
-			So(hc.TimeOfFirstCriticalError, ShouldResemble, time.Time{})
+			// timeOfFirstCriticalError not set
+			So(hc.timeOfFirstCriticalError, ShouldResemble, time.Time{})
 		})
 		Convey("Then an unhealthy check that has been healthy in the past should result in the app reporting back as warning", func() {
 			statuses := []CheckState{unhealthyStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError not set
-			So(hc.TimeOfFirstCriticalError, ShouldResemble, time.Time{})
+			// timeOfFirstCriticalError not set
+			So(hc.timeOfFirstCriticalError, ShouldResemble, time.Time{})
 		})
 		Convey("Then a critical check that has never been healthy should result in the app reporting back as warning and updating timestamp for first critical error", func() {
 			statuses := []CheckState{criticalNeverHealthyStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError set to this check's failure time
-			So(hc.TimeOfFirstCriticalError, ShouldHappenWithin, time.Second, t0)
+			// timeOfFirstCriticalError set to this check's failure time
+			So(hc.timeOfFirstCriticalError, ShouldHappenWithin, time.Second, t0)
 		})
 		Convey("Then a critical check that has been healthy in the past should result in the app reporting back as warning and updating timestamp for first critical error", func() {
 			statuses := []CheckState{oldCriticalStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError set to this check's failure time
-			So(hc.TimeOfFirstCriticalError, ShouldHappenWithin, time.Second, t0)
+			// timeOfFirstCriticalError set to this check's failure time
+			So(hc.timeOfFirstCriticalError, ShouldHappenWithin, time.Second, t0)
 		})
 	})
 
@@ -590,32 +590,32 @@ func TestHandlerSingleCheck(t *testing.T) {
 		hc := HealthCheck{
 			Version:                  testVersion,
 			StartTime:                t0,
-			CriticalErrorTimeout:     criticalErrTimeout,
-			TimeOfFirstCriticalError: t10,
-			Tickers:                  nil,
+			criticalErrorTimeout:     criticalErrTimeout,
+			timeOfFirstCriticalError: t10,
+			tickers:                  nil,
 		}
 
 		Convey("Then a healthy check should result in the app reporting back as healthy", func() {
 			statuses := []CheckState{healthyNeverUnhealthyStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusOK, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError not updated
-			So(hc.TimeOfFirstCriticalError, ShouldResemble, t10)
+			// timeOfFirstCriticalError not updated
+			So(hc.timeOfFirstCriticalError, ShouldResemble, t10)
 		})
 		Convey("Then a recent critical check happening before the timeout expires should result in the app reporting back as warning", func() {
 			statuses := []CheckState{freshCriticalStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError not updated
-			So(hc.TimeOfFirstCriticalError, ShouldResemble, t10)
+			// timeOfFirstCriticalError not updated
+			So(hc.timeOfFirstCriticalError, ShouldResemble, t10)
 		})
 		Convey("Then a critical check that has been critical for longer than the timeout and the value of first critical error, "+
 			"should result in the app reporting back as warning and not updating timestamp for first critical error", func() {
 			statuses := []CheckState{oldCriticalStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError not updated
-			So(hc.TimeOfFirstCriticalError, ShouldResemble, t10)
+			// timeOfFirstCriticalError not updated
+			So(hc.timeOfFirstCriticalError, ShouldResemble, t10)
 		})
 	})
 
@@ -624,33 +624,33 @@ func TestHandlerSingleCheck(t *testing.T) {
 		hc := HealthCheck{
 			Version:                  testVersion,
 			StartTime:                t0,
-			CriticalErrorTimeout:     criticalErrTimeout,
-			TimeOfFirstCriticalError: t20,
-			Tickers:                  nil,
+			criticalErrorTimeout:     criticalErrTimeout,
+			timeOfFirstCriticalError: t20,
+			tickers:                  nil,
 		}
 
 		Convey("Then a healthy check should result in the app reporting back as healthy", func() {
 			statuses := []CheckState{healthyNeverUnhealthyStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusOK, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError not set
-			So(hc.TimeOfFirstCriticalError, ShouldResemble, t20)
+			// timeOfFirstCriticalError not set
+			So(hc.timeOfFirstCriticalError, ShouldResemble, t20)
 		})
 		Convey("Then a recent critical check (last success more recent than first critical) should result in the app reporting back as warning "+
 			"and refresh timestamp for first critical error", func() {
 			statuses := []CheckState{freshCriticalStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError set to this check's failure time
-			So(hc.TimeOfFirstCriticalError, ShouldHappenWithin, time.Second, t0)
+			// timeOfFirstCriticalError set to this check's failure time
+			So(hc.timeOfFirstCriticalError, ShouldHappenWithin, time.Second, t0)
 		})
 		Convey("Then a critical check (last success older than first critical) should result in the app reporting back as critical "+
 			"and not refreshing timestamp for first critical error", func() {
 			statuses := []CheckState{oldCriticalStatus}
 			hc.Checks = createChecksSlice(statuses, true)
 			runHealthHandlerAndTest(t, &hc, StatusCritical, testVersion, t0, statuses)
-			// TimeOfFirstCriticalError set to this check's failure time
-			So(hc.TimeOfFirstCriticalError, ShouldResemble, t20)
+			// timeOfFirstCriticalError set to this check's failure time
+			So(hc.timeOfFirstCriticalError, ShouldResemble, t20)
 		})
 	})
 
@@ -716,45 +716,45 @@ func TestHandlerMultipleChecks(t *testing.T) {
 	Convey("Given a complete Healthy set of checks the app should report back as healthy", t, func() {
 		statuses := []CheckState{healthyStatus1, healthyStatus2, healthyStatus3}
 		hc := createHealthCheck(statuses, testStartTime, 10*time.Minute, true)
-		hc.TimeOfFirstCriticalError = testStartTime.Add(-30 * time.Minute)
+		hc.timeOfFirstCriticalError = testStartTime.Add(-30 * time.Minute)
 		runHealthHandlerAndTest(t, &hc, StatusOK, testVersion, testStartTime, statuses)
 	})
 	Convey("Given a healthy app and an unhealthy app", t, func() {
 		statuses := []CheckState{healthyStatus1, unhealthyStatus}
 		hc := createHealthCheck(statuses, testStartTime, 15*time.Second, true)
-		hc.TimeOfFirstCriticalError = testStartTime.Add(-30 * time.Minute)
+		hc.timeOfFirstCriticalError = testStartTime.Add(-30 * time.Minute)
 		runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, testStartTime, statuses)
 	})
 	Convey("Given a healthy app and a critical app that is beyond the threshold", t, func() {
 		checks := []CheckState{healthyStatus1, criticalStatus}
 		hc := createHealthCheck(checks, testStartTime, 10*time.Minute, true)
-		hc.TimeOfFirstCriticalError = testStartTime.Add(-22 * time.Minute)
+		hc.timeOfFirstCriticalError = testStartTime.Add(-22 * time.Minute)
 		runHealthHandlerAndTest(t, &hc, StatusCritical, testVersion, testStartTime, checks)
 	})
 	Convey("Given an unhealthy app and an app that has just turned critical and is under the critical threshold", t, func() {
 		statuses := []CheckState{unhealthyStatus, freshCriticalStatus}
 		hc := createHealthCheck(statuses, testStartTime, 10*time.Minute, true)
-		hc.TimeOfFirstCriticalError = testStartTime.Add(-1 * time.Minute)
+		hc.timeOfFirstCriticalError = testStartTime.Add(-1 * time.Minute)
 		runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, testStartTime, statuses)
 	})
 	Convey("Given an unhealthy app and an app that has been critical for longer than the critical threshold", t, func() {
 		statuses := []CheckState{unhealthyStatus, criticalStatus}
 		hc := createHealthCheck(statuses, testStartTime, 10*time.Minute, true)
-		hc.TimeOfFirstCriticalError = testStartTime.Add(-22 * time.Minute)
+		hc.timeOfFirstCriticalError = testStartTime.Add(-22 * time.Minute)
 		runHealthHandlerAndTest(t, &hc, StatusCritical, testVersion, testStartTime, statuses)
 	})
 	Convey("Given an app just started up", t, func() {
 		statuses := []CheckState{freshCriticalStatus}
 		justStartedTime := time.Now().UTC()
 		hc := createHealthCheck(statuses, justStartedTime, 10*time.Minute, false)
-		hc.TimeOfFirstCriticalError = justStartedTime
+		hc.timeOfFirstCriticalError = justStartedTime
 		runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, justStartedTime, nil)
 	})
 	Convey("Given an app has begun to start but not finished starting up completely", t, func() {
 		statuses := []CheckState{freshCriticalStatus}
 		justStartedTime := time.Now().UTC()
 		hc := createHealthCheck(statuses, justStartedTime, 10*time.Minute, true)
-		hc.TimeOfFirstCriticalError = justStartedTime
+		hc.timeOfFirstCriticalError = justStartedTime
 		runHealthHandlerAndTest(t, &hc, StatusWarning, testVersion, justStartedTime, statuses)
 	})
 	Convey("Given no apps", t, func() {
@@ -764,9 +764,9 @@ func TestHandlerMultipleChecks(t *testing.T) {
 			Checks:                   checks,
 			Version:                  testVersion,
 			StartTime:                testStartTime,
-			CriticalErrorTimeout:     10 * time.Minute,
-			TimeOfFirstCriticalError: testStartTime.Add(-30 * time.Minute),
-			Tickers:                  nil,
+			criticalErrorTimeout:     10 * time.Minute,
+			timeOfFirstCriticalError: testStartTime.Add(-30 * time.Minute),
+			tickers:                  nil,
 		}
 		runHealthHandlerAndTest(t, &hc, StatusOK, testVersion, testStartTime, statuses)
 	})
@@ -801,8 +801,8 @@ func createHealthCheck(statuses []CheckState, startTime time.Time, critErrTimeou
 		Checks:               createChecksSlice(statuses, hasPreviousCheck),
 		Version:              testVersion,
 		StartTime:            startTime,
-		CriticalErrorTimeout: critErrTimeout,
-		Tickers:              nil,
+		criticalErrorTimeout: critErrTimeout,
+		tickers:              nil,
 	}
 	return hc
 }

--- a/healthcheck/healthcheck_test.go
+++ b/healthcheck/healthcheck_test.go
@@ -68,14 +68,14 @@ func TestCreate(t *testing.T) {
 		So(hc.Version.LanguageVersion, ShouldEqual, "1.12")
 		So(hc.Version.Version, ShouldEqual, "1.0.0")
 		So(hc.StartTime, ShouldHappenBetween, timeBeforeCreation, time.Now().UTC())
-		So(hc.CriticalErrorTimeout, ShouldEqual, criticalTimeout)
-		So(len(hc.Tickers), ShouldEqual, 1)
+		So(hc.criticalErrorTimeout, ShouldEqual, criticalTimeout)
+		So(len(hc.tickers), ShouldEqual, 1)
 		Convey("After check function should have run, ensure the check state has updated", func() {
 			time.Sleep(2 * interval)
 
-			hc.Tickers[0].check.state.mutex.RLock()
-			So(*hc.Tickers[0].check.state.LastChecked(), ShouldHappenOnOrBetween, timeBeforeCreation, time.Now().UTC())
-			hc.Tickers[0].check.state.mutex.RUnlock()
+			hc.tickers[0].check.state.mutex.RLock()
+			So(*hc.tickers[0].check.state.LastChecked(), ShouldHappenOnOrBetween, timeBeforeCreation, time.Now().UTC())
+			hc.tickers[0].check.state.mutex.RUnlock()
 		})
 	})
 
@@ -95,18 +95,18 @@ func TestCreate(t *testing.T) {
 		So(hc.Version.LanguageVersion, ShouldEqual, "1.12")
 		So(hc.Version.Version, ShouldEqual, "1.0.0")
 		So(hc.StartTime, ShouldHappenBetween, timeBeforeCreation, time.Now().UTC())
-		So(hc.CriticalErrorTimeout, ShouldEqual, criticalTimeout)
-		So(len(hc.Tickers), ShouldEqual, 2)
+		So(hc.criticalErrorTimeout, ShouldEqual, criticalTimeout)
+		So(len(hc.tickers), ShouldEqual, 2)
 		Convey("After the check functions should have run, ensure both check states have updated", func() {
 			time.Sleep(2 * interval)
 
-			hc.Tickers[0].check.state.mutex.RLock()
-			So(*hc.Tickers[0].check.state.LastChecked(), ShouldHappenOnOrBetween, timeBeforeCreation, time.Now().UTC())
-			hc.Tickers[0].check.state.mutex.RUnlock()
+			hc.tickers[0].check.state.mutex.RLock()
+			So(*hc.tickers[0].check.state.LastChecked(), ShouldHappenOnOrBetween, timeBeforeCreation, time.Now().UTC())
+			hc.tickers[0].check.state.mutex.RUnlock()
 
-			hc.Tickers[1].check.state.mutex.RLock()
-			So(*hc.Tickers[1].check.state.LastChecked(), ShouldHappenOnOrBetween, timeBeforeCreation, time.Now().UTC())
-			hc.Tickers[1].check.state.mutex.RUnlock()
+			hc.tickers[1].check.state.mutex.RLock()
+			So(*hc.tickers[1].check.state.LastChecked(), ShouldHappenOnOrBetween, timeBeforeCreation, time.Now().UTC())
+			hc.tickers[1].check.state.mutex.RUnlock()
 		})
 	})
 
@@ -124,9 +124,9 @@ func TestCreate(t *testing.T) {
 		So(hc.Version.LanguageVersion, ShouldEqual, "1.12")
 		So(hc.Version.Version, ShouldEqual, "1.0.0")
 		So(hc.StartTime, ShouldHappenBetween, timeBeforeCreation, time.Now().UTC())
-		So(hc.CriticalErrorTimeout, ShouldEqual, criticalTimeout)
+		So(hc.criticalErrorTimeout, ShouldEqual, criticalTimeout)
 		So(len(hc.Checks), ShouldEqual, 0)
-		So(len(hc.Tickers), ShouldEqual, 0)
+		So(len(hc.tickers), ShouldEqual, 0)
 	})
 
 	Convey("Create a new Health Check given a broken check function", t, func() {
@@ -139,9 +139,9 @@ func TestCreate(t *testing.T) {
 		Convey("After check function has run, ensure it has correctly stored the results", func() {
 			time.Sleep(2 * interval)
 
-			hc.Tickers[0].check.state.mutex.RLock()
-			s := *hc.Tickers[0].check.state
-			hc.Tickers[0].check.state.mutex.RUnlock()
+			hc.tickers[0].check.state.mutex.RLock()
+			s := *hc.tickers[0].check.state
+			hc.tickers[0].check.state.mutex.RUnlock()
 
 			s.mutex = nil
 			So(s, ShouldResemble, CheckState{})
@@ -161,20 +161,20 @@ func TestCreate(t *testing.T) {
 		// no `defer hc.Stop()` because of `cancel()`
 
 		So(err, ShouldBeNil)
-		So(hc.Started, ShouldBeTrue)
+		So(hc.context, ShouldNotBeNil)
 
 		Convey("When the check function has time to run, and the context is cancelled", func() {
 			time.Sleep(2 * interval)
 
-			So(len(hc.Tickers), ShouldEqual, 1)
-			So(hc.Tickers[0].check.state, ShouldPointTo, hc.Checks[0].state)
-			So(hc.Tickers[0].isStopping(), ShouldBeFalse)
+			So(len(hc.tickers), ShouldEqual, 1)
+			So(hc.tickers[0].check.state, ShouldPointTo, hc.Checks[0].state)
+			So(hc.tickers[0].isStopping(), ShouldBeFalse)
 
 			cancel()
 
 			Convey("Then the tickers are stopped/stopping", func() {
 				time.Sleep(2 * interval)
-				So(hc.Tickers[0].isStopping(), ShouldBeTrue)
+				So(hc.tickers[0].isStopping(), ShouldBeTrue)
 			})
 		})
 	})
@@ -209,7 +209,7 @@ func TestCreate(t *testing.T) {
 			So(hc.Checks[0].state.statusCode, ShouldEqual, statusCode)
 			So(hc.Checks[0].state.lastChecked, ShouldEqual, &now)
 			So(hc.Checks[0].state.lastSuccess, ShouldEqual, &now)
-			hc.Tickers[0].check.state.mutex.RUnlock()
+			hc.tickers[0].check.state.mutex.RUnlock()
 		})
 	})
 }
@@ -233,7 +233,7 @@ func TestAddCheck(t *testing.T) {
 			defer hc.Stop()
 
 			time.Sleep(2 * interval)
-			So(len(hc.Tickers), ShouldEqual, 1)
+			So(len(hc.tickers), ShouldEqual, 1)
 		})
 	})
 
@@ -251,7 +251,7 @@ func TestAddCheck(t *testing.T) {
 			defer hc.Stop()
 
 			time.Sleep(2 * interval)
-			So(len(hc.Tickers), ShouldEqual, 2)
+			So(len(hc.tickers), ShouldEqual, 2)
 		})
 	})
 
@@ -261,13 +261,13 @@ func TestAddCheck(t *testing.T) {
 		defer hc.Stop()
 
 		So(err, ShouldBeNil)
-		origNumberOfTickers := len(hc.Tickers)
-		Convey("When you add another check - too late", func() {
+		origNumberOftickers := len(hc.tickers)
+		Convey("When you add another check", func() {
 			err := hc.AddCheck(cf)
-			Convey("Then there should be no increase in the number of tickers", func() {
-				So(err, ShouldNotBeNil)
-				time.Sleep(2 * interval)
-				So(len(hc.Tickers), ShouldEqual, origNumberOfTickers)
+			time.Sleep(2 * interval)
+			Convey("Then the number of tickers should increase by one", func() {
+				So(err, ShouldBeNil)
+				So(len(hc.tickers), ShouldEqual, origNumberOftickers + 1)
 			})
 		})
 	})
@@ -286,7 +286,7 @@ func TestAddCheck(t *testing.T) {
 			defer hc.Stop()
 
 			time.Sleep(2 * interval)
-			So(len(hc.Tickers), ShouldEqual, 0)
+			So(len(hc.tickers), ShouldEqual, 0)
 		})
 	})
 }

--- a/healthcheck/ticker.go
+++ b/healthcheck/ticker.go
@@ -44,13 +44,11 @@ func (ticker *ticker) start(ctx context.Context) {
 
 // runCheck runs a checker function of the check associated with the ticker
 func (ticker *ticker) runCheck(ctx context.Context) {
-	ticker.check.mutex.Lock()
-	defer ticker.check.mutex.Unlock()
 	err := ticker.check.checker(ctx, ticker.check.state)
 	if err != nil {
 		name := "no check has been made yet"
 		if ticker.check.state != nil {
-			name = ticker.check.state.Name
+			name = ticker.check.state.Name()
 		}
 		log.Event(nil, "failed", log.Error(err), log.Data{"external_service": name})
 		return


### PR DESCRIPTION
### What

To ensure consistent and protective use of the CheckState pointer that
gets passed to the Checker functions the fields have been changed to
unexported and a helpful `Update()` function has been added to manage
the correct updates to the state including time calculations.  This
should prevent any race conditions if Checker implementations store the
pointer and will also simplify the Checker implementations.

### Who can review

Anyone but me.
