### PR TITLE
Return global HTTP Code according to global health status

### DIFF
--- a/healthcheck/handler.go
+++ b/healthcheck/handler.go
@@ -25,6 +25,15 @@ func (hc *HealthCheck) Handler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	switch hc.Status {
+	case StatusOK:
+		w.WriteHeader(http.StatusOK)
+	case StatusWarning:
+		w.WriteHeader(http.StatusTooManyRequests)
+	default:
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+
 	_, err = w.Write(b)
 	if err != nil {
 		log.Event(ctx, "failed to write bytes for http response", log.Error(err))

--- a/healthcheck/healthcheck_test.go
+++ b/healthcheck/healthcheck_test.go
@@ -65,7 +65,7 @@ func TestNew(t *testing.T) {
 		So(hc.Version.Language, ShouldEqual, language)
 		So(hc.Version.LanguageVersion, ShouldEqual, "1.12")
 		So(hc.Version.Version, ShouldEqual, "1.0.0")
-		So(hc.StartTime, ShouldHappenBetween, timeBeforeCreation, time.Now().UTC())
+		So(hc.StartTime, ShouldHappenOnOrBetween, timeBeforeCreation, time.Now().UTC())
 		So(hc.criticalErrorTimeout, ShouldEqual, criticalTimeout)
 		So(len(hc.Checks), ShouldEqual, 0)
 		So(len(hc.tickers), ShouldEqual, 0)
@@ -86,7 +86,7 @@ func TestNew(t *testing.T) {
 		So(hc.Version.Language, ShouldEqual, language)
 		So(hc.Version.LanguageVersion, ShouldEqual, "1.12")
 		So(hc.Version.Version, ShouldEqual, "1.0.0")
-		So(hc.StartTime, ShouldHappenBetween, timeBeforeCreation, time.Now().UTC())
+		So(hc.StartTime, ShouldHappenOnOrBetween, timeBeforeCreation, time.Now().UTC())
 		So(hc.criticalErrorTimeout, ShouldEqual, criticalTimeout)
 		So(len(hc.tickers), ShouldEqual, 1)
 		Convey("After check function should have run, ensure the check state has updated", func() {
@@ -116,7 +116,7 @@ func TestNew(t *testing.T) {
 		So(hc.Version.Language, ShouldEqual, language)
 		So(hc.Version.LanguageVersion, ShouldEqual, "1.12")
 		So(hc.Version.Version, ShouldEqual, "1.0.0")
-		So(hc.StartTime, ShouldHappenBetween, timeBeforeCreation, time.Now().UTC())
+		So(hc.StartTime, ShouldHappenOnOrBetween, timeBeforeCreation, time.Now().UTC())
 		So(hc.criticalErrorTimeout, ShouldEqual, criticalTimeout)
 		So(len(hc.tickers), ShouldEqual, 2)
 		Convey("After the check functions should have run, ensure both check states have updated", func() {


### PR DESCRIPTION
### What

- The handler now returns the status code as expected (depending on the global health status):
  - Global Status OK -> HTTP 200
  - Global Status Warning -> HTTP 429
  - Global Status Critical -> HTTP 500
- Fixed unit tests to cover this change
- Fixed unit tests timing corner case (ShouldHappenBetween -> ShouldHappenOnOrBetween)

### How to review

- Make sure the changes make sense
- Unit tests should pass
- I tried to use this change in dp-kafka and dp-dataset-exporter, and I see the expected HTTP code being returned

### Who can review

Anyone