### PR TITLE
Ensure healthcheck.Stop() function blocks

### DIFF
--- a/healthcheck/ticker.go
+++ b/healthcheck/ticker.go
@@ -36,7 +36,7 @@ func (ticker *ticker) start(ctx context.Context) {
 			case <-ticker.closing:
 				return
 			case <-ticker.timeTicker.C:
-				go ticker.runCheck(ctx)
+				ticker.runCheck(ctx)
 			}
 		}
 	}()


### PR DESCRIPTION
### What
When attempting to gracefully shut down services, calling stop on the health check did not wait until current checks had cleanly finished. This caused intermittent race conditions on shutdown for some health checkers (particularly the neo4j checker). The race condition occurred due to the healthchecker trying to close its connection, and the main app also trying to close its connection pool. Waiting for the existing check to finish ensures that the rest of the application can shutdown cleanly.

- ensure healthcheck.Stop() function blocks until current health checks are complete.
- health checks running in their own go routine meant there was no synchronisation on when the check finished.
- added tests for the close function, to ensure checkers finish before the function returns.

### How to review

- Review changes
- Ensure tests pass

### Who can review

Anyone who dares 😃 
