### PR TITLE
moved waitgroup to HealthCheck struct instead of ticker

### DIFF
--- a/healthcheck/handler.go
+++ b/healthcheck/handler.go
@@ -25,6 +25,8 @@ func (hc *HealthCheck) Handler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
 	switch hc.Status {
 	case StatusOK:
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
### What

- Moved WaitGroup from ticker to healthcheck (single waitgroup for all tickers, and wait on stop)
- This is supposed to fix the memory leak that we observed in `develp` - we should verify it once a service is using this change.
- Added `Conent-type` `application/json` header

### How to review

- Make sure changes make sense
- Unit tests should pass

### Who can review

Anyone