### PR TITLE
Update example to use values of 30s and 90s

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,8 @@ Adding a health check to an app
         ...
 
         // Likely these values would come from your app's config
-        criticalTimeout := time.Minute
-        interval := 10 * time.Second
-
-        ...
-
-        // Likely these values would come from your app's config
-        criticalTimeout := time.Minute
-        interval := 10 * time.Second
+        criticalTimeout := 90 * time.Second // defined by env var HEALTHCHECK_CRITICAL_TIMEOUT
+        interval := 30 * time.Second // defined by env var HEALTHCHECK_INTERVAL
 
         ...
 


### PR DESCRIPTION
### What

- Example uses the expected default values of:
  - 30 seconds for interval
  - 90s for critical timeout
- It also documents the env vars that will define those values in development and production environments.

### How to review

Make sure changes will help developers using this library, to use the expected default values and config env vars.

### Who can review

Anyone