### PR TITLE
add call to runCheck as soon as ticker starts

### DIFF
--- a/healthcheck/ticker.go
+++ b/healthcheck/ticker.go
@@ -30,6 +30,11 @@ func createTicker(interval time.Duration, check *Check) *ticker {
 func (ticker *ticker) start(ctx context.Context, wg *sync.WaitGroup) {
 	go func() {
 		defer close(ticker.closed)
+
+		// first run check once on application start
+		wg.Add(1)
+		ticker.runCheck(ctx, wg)
+
 		for {
 			select {
 			case <-ctx.Done():
@@ -42,10 +47,6 @@ func (ticker *ticker) start(ctx context.Context, wg *sync.WaitGroup) {
 			}
 		}
 	}()
-
-	// run check as a one of on application start
-	wg.Add(1)
-	ticker.runCheck(ctx, wg)
 }
 
 // runCheck runs a checker function of the check associated with the ticker, notifying the provided waitgroup

--- a/healthcheck/ticker.go
+++ b/healthcheck/ticker.go
@@ -42,11 +42,14 @@ func (ticker *ticker) start(ctx context.Context, wg *sync.WaitGroup) {
 			}
 		}
 	}()
+
+	// run check as a one of on application start
+	wg.Add(1)
+	ticker.runCheck(ctx, wg)
 }
 
 // runCheck runs a checker function of the check associated with the ticker, notifying the provided waitgroup
 func (ticker *ticker) runCheck(ctx context.Context, wg *sync.WaitGroup) {
-
 	defer wg.Done()
 
 	err := ticker.check.checker(ctx, ticker.check.state)


### PR DESCRIPTION
### What

Added a call to runCheck to the ticker's start function so checks are run immediately on application start rather than wait for 1x check interval.

### How to review

Check change makes sense. You can clone branch and use go.mod's replace functionality to check the change has an impact. When using the updated package you should noticed that health checks to downstream services are being performed immediately as the app starts rather than waiting the default interval time.

### Who can review

Anyone
