### PR TITLE
Bugfix: Update global app state independently of calls to `/health` endpoint

### DIFF
--- a/healthcheck/handler.go
+++ b/healthcheck/handler.go
@@ -60,11 +60,11 @@ func (hc *HealthCheck) areChecksStartingUp(checks []*Check) bool {
 
 // getAppStatus returns a status as string as to the overall current apps health based on its dependent apps health
 func (hc *HealthCheck) getAppStatus(ctx context.Context) string {
-	if hc.areChecksStartingUp(hc.Checks) {
+	if hc.isAppStartingUp() {
 		log.Warn(ctx, "a dependency is still starting up")
 		return StatusWarning
 	}
-	return hc.areChecksHealthy(hc.Checks)
+	return hc.isAppHealthy()
 }
 
 func (hc *HealthCheck) getChecksStatus(checks []*Check) string {

--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -142,7 +142,7 @@ func (hc *HealthCheck) startTracker(ctx context.Context) {
 	}(ctx)
 }
 
-// loopAppStartingUp pools the app state until it has fully started (all checks have run)
+// loopAppStartingUp polls the app state until it has fully started (all checks have run)
 // - The polling period is 10% of the checkers interval, with jitter.
 // - The state is updated to 'WARNING' until the app has fully started: then it is updated to the real status according to checkers.
 func (hc *HealthCheck) loopAppStartingUp(ctx context.Context) {

--- a/healthcheck/subscription.go
+++ b/healthcheck/subscription.go
@@ -1,7 +1,9 @@
 package healthcheck
 
 import (
+	"context"
 	"sync"
+	"time"
 )
 
 //go:generate moq -out ./mock/subscription.go -pkg mock . Subscriber
@@ -78,6 +80,13 @@ func (hc *HealthCheck) healthChangeCallback() *sync.WaitGroup {
 	hc.subsMutex.Lock()
 	defer hc.subsMutex.Unlock()
 
+	// Update global app status, so that we don't rely on `/health` being called
+	now := time.Now().UTC()
+	newStatus := hc.getAppStatus(context.Background())
+	hc.SetStatus(newStatus)
+	hc.Uptime = now.Sub(hc.StartTime) / time.Millisecond
+
+	// Notify all subscribers of the new health state for their subscribed checkers
 	for s, checks := range hc.subscribers {
 		checkList := []*Check{}
 		for check := range checks {

--- a/healthcheck/subscription.go
+++ b/healthcheck/subscription.go
@@ -80,12 +80,6 @@ func (hc *HealthCheck) healthChangeCallback() *sync.WaitGroup {
 	hc.subsMutex.Lock()
 	defer hc.subsMutex.Unlock()
 
-	// Update global app status, so that we don't rely on `/health` being called
-	now := time.Now().UTC()
-	newStatus := hc.getAppStatus(context.Background())
-	hc.SetStatus(newStatus)
-	hc.Uptime = now.Sub(hc.StartTime) / time.Millisecond
-
 	// Notify all subscribers of the new health state for their subscribed checkers
 	for s, checks := range hc.subscribers {
 		checkList := []*Check{}
@@ -99,6 +93,12 @@ func (hc *HealthCheck) healthChangeCallback() *sync.WaitGroup {
 			subscriber.OnHealthUpdate(status)
 		}(s)
 	}
+
+	// Update global app status, so that we don't rely on `/health` being called
+	now := time.Now().UTC()
+	newStatus := hc.getAppStatus(context.Background())
+	hc.SetStatus(newStatus)
+	hc.Uptime = now.Sub(hc.StartTime) / time.Millisecond
 
 	return wg
 }

--- a/healthcheck/subscription_test.go
+++ b/healthcheck/subscription_test.go
@@ -131,7 +131,8 @@ func TestNotifyHealthUpdate(t *testing.T) {
 				sub1: {c1: {}, c2: {}},
 				sub2: {c2: {}, c3: {}},
 			},
-			subsMutex: &sync.Mutex{},
+			statusLock: &sync.RWMutex{},
+			subsMutex:  &sync.Mutex{},
 		}
 
 		Convey(`Then calling healthChangeCallback results in the status being updated for all the subscribers, 


### PR DESCRIPTION
### What

Bugfix:
- Update global app state to `CRITICAL` after the critical timeout has expired and all checkers have run (by creating a tracker go-routine when the health check is started)
- Update global app state not only when `/health` endpoint is called, but also in the callback.

Trello card:
https://trello.com/c/pOPgQzPu/5195-application-health-state-update-delayed

### How to review

- Make sure code changes make sense
- Make sure unit tests make sense and pass
- (info only) tested locally by doing the following:
  - In an app go.mod, replace dp-healthcheck dependency with a local checkout with this branch
  - In health check Start, add an extra go-routine with a periodic logging loop
```
func (hc *HealthCheck) Start(ctx context.Context) {
    ....
    hc.startDebug(ctx)
}

// DEBUG ONLY!
func (hc *HealthCheck) startDebug(ctx context.Context) {
	hc.tickersWaitgroup.Add(1)
	go func() {
		defer hc.tickersWaitgroup.Done()
		for {
			select {
			case <-time.After(3 * time.Second):
				log.Info(ctx, "+++ DEBUG - Status", log.Data{"status": hc.GetStatus()})
			case <-ctx.Done():
				log.Info(ctx, "+++ DEBUG - Stopper closed")
				return
			case <-hc.stopper:
				log.Info(ctx, "+++ DEBUG - Stopper closed")
				return
			}
		}
	}()
}
```
  - Sart the app, without any dependency: `make debug`
  - Check the logs and validate that after 1.5 min (or Critical Timeout) the state changes from Warning to Critical.

### Who can review

Anyone
