### PR TITLE
fixed data race by creating and using SetStatusAndUptime

### DIFF
--- a/healthcheck/handler.go
+++ b/healthcheck/handler.go
@@ -13,12 +13,10 @@ var minTime = time.Unix(0, 0)
 
 // Handler responds to an http request for the current health status
 func (hc *HealthCheck) Handler(w http.ResponseWriter, req *http.Request) {
-	now := time.Now().UTC()
 	ctx := req.Context()
 
 	newStatus := hc.getAppStatus(ctx)
-	hc.SetStatus(newStatus)
-	hc.Uptime = now.Sub(hc.StartTime) / time.Millisecond
+	hc.SetStatusAndUptime(newStatus)
 
 	b, err := json.Marshal(hc)
 	if err != nil {

--- a/healthcheck/subscription.go
+++ b/healthcheck/subscription.go
@@ -3,7 +3,6 @@ package healthcheck
 import (
 	"context"
 	"sync"
-	"time"
 )
 
 //go:generate moq -out ./mock/subscription.go -pkg mock . Subscriber
@@ -95,10 +94,8 @@ func (hc *HealthCheck) healthChangeCallback() *sync.WaitGroup {
 	}
 
 	// Update global app status, so that we don't rely on `/health` being called
-	now := time.Now().UTC()
 	newStatus := hc.getAppStatus(context.Background())
-	hc.SetStatus(newStatus)
-	hc.Uptime = now.Sub(hc.StartTime) / time.Millisecond
+	hc.SetStatusAndUptime(newStatus)
 
 	return wg
 }


### PR DESCRIPTION
### What

This PR fixes the data race observed when running the latest versions of `dp-healthcheck` (created as a consequence of updating uptime from the handler and also from the subscription-based callback). This data race can be observed sometimes when running the Cantabular pipeline.

In this PR:
- Created `SetStatusAndUptime` func to safely update the status and upTime after acquiring the lock.
- Used the new func from both the handler and the subscription callback

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- Make sure all calls to `SetStatus` have been replaced with `SetStatusAndUptime`

### Who can review

Anyone

-----

Log of data race:
```
dp-recipe-api_1                           | ==================
dp-recipe-api_1                           | WARNING: DATA RACE
dp-recipe-api_1                           | Write at 0x00c0001864e8 by goroutine 49:
dp-recipe-api_1                           |   github.com/ONSdigital/dp-healthcheck/healthcheck.(*HealthCheck).Handler()
dp-recipe-api_1                           |       /go/.go/path/pkg/mod/github.com/!o!n!sdigital/dp-healthcheck@v1.2.1/healthcheck/handler.go:21 +0x219
dp-recipe-api_1                           |   github.com/ONSdigital/dp-recipe-api/service.HealthChecker.Handler-fm()
dp-recipe-api_1                           |       /go/service/interfaces.go:32 +0x6d
dp-recipe-api_1                           |   github.com/ONSdigital/dp-recipe-api/service.healthcheckMiddleware.func1.1()
dp-recipe-api_1                           |       /go/service/service.go:137 +0x15a
dp-recipe-api_1                           |   net/http.HandlerFunc.ServeHTTP()
dp-recipe-api_1                           |       /usr/local/go/src/net/http/server.go:2050 +0x51
dp-recipe-api_1                           |   github.com/ONSdigital/log.go/v2/log.Middleware.func1()
dp-recipe-api_1                           |       /go/.go/path/pkg/mod/github.com/!o!n!sdigital/log.go/v2@v2.0.9/log/middleware.go:46 +0x437
dp-recipe-api_1                           |   net/http.HandlerFunc.ServeHTTP()
dp-recipe-api_1                           |       /usr/local/go/src/net/http/server.go:2050 +0x51
dp-recipe-api_1                           |   github.com/ONSdigital/dp-net/request.HandlerRequestID.func1.1()
dp-recipe-api_1                           |       /go/.go/path/pkg/mod/github.com/!o!n!sdigital/dp-net@v1.2.0/request/request.go:61 +0x331
dp-recipe-api_1                           |   net/http.HandlerFunc.ServeHTTP()
dp-recipe-api_1                           |       /usr/local/go/src/net/http/server.go:2050 +0x51
dp-recipe-api_1                           |   net/http.serverHandler.ServeHTTP()
dp-recipe-api_1                           |       /usr/local/go/src/net/http/server.go:2868 +0xca
dp-recipe-api_1                           |   net/http.(*conn).serve()
dp-recipe-api_1                           |       /usr/local/go/src/net/http/server.go:1933 +0x87d
dp-recipe-api_1                           |
dp-recipe-api_1                           | Previous write at 0x00c0001864e8 by goroutine 31:
dp-recipe-api_1                           |   github.com/ONSdigital/dp-healthcheck/healthcheck.(*HealthCheck).healthChangeCallback()
dp-recipe-api_1                           |       /go/.go/path/pkg/mod/github.com/!o!n!sdigital/dp-healthcheck@v1.2.1/healthcheck/subscription.go:101 +0x5d0
dp-recipe-api_1                           |   github.com/ONSdigital/dp-healthcheck/healthcheck.(*HealthCheck).healthChangeCallback-fm()
dp-recipe-api_1                           |       /go/.go/path/pkg/mod/github.com/!o!n!sdigital/dp-healthcheck@v1.2.1/healthcheck/subscription.go:77 +0x4a
dp-recipe-api_1                           |   github.com/ONSdigital/dp-healthcheck/healthcheck.(*CheckState).Update.func1()
dp-recipe-api_1                           |       /go/.go/path/pkg/mod/github.com/!o!n!sdigital/dp-healthcheck@v1.2.1/healthcheck/check.go:137 +0xbd
dp-recipe-api_1                           |   github.com/ONSdigital/dp-healthcheck/healthcheck.(*CheckState).Update()
dp-recipe-api_1                           |       /go/.go/path/pkg/mod/github.com/!o!n!sdigital/dp-healthcheck@v1.2.1/healthcheck/check.go:159 +0x418
dp-recipe-api_1                           |   github.com/ONSdigital/dp-api-clients-go/health.(*Client).Checker()
dp-recipe-api_1                           |       /go/.go/path/pkg/mod/github.com/!o!n!sdigital/dp-api-clients-go@v1.43.0/health/health.go:98 +0x4b4
dp-recipe-api_1                           |   github.com/ONSdigital/dp-api-clients-go/identity.Client.Checker()
dp-recipe-api_1                           |       /go/.go/path/pkg/mod/github.com/!o!n!sdigital/dp-api-clients-go@v1.43.0/identity/authentication.go:67 +0x74
dp-recipe-api_1                           |   github.com/ONSdigital/dp-api-clients-go/identity.Client.Checker-fm()
dp-recipe-api_1                           |       /go/.go/path/pkg/mod/github.com/!o!n!sdigital/dp-api-clients-go@v1.43.0/identity/authentication.go:66 +0x33
dp-recipe-api_1                           |   github.com/ONSdigital/dp-healthcheck/healthcheck.(*ticker).runCheck()
dp-recipe-api_1                           |       /go/.go/path/pkg/mod/github.com/!o!n!sdigital/dp-healthcheck@v1.2.1/healthcheck/ticker.go:56 +0x13e
dp-recipe-api_1                           |   github.com/ONSdigital/dp-healthcheck/healthcheck.(*ticker).start.func1()
dp-recipe-api_1                           |       /go/.go/path/pkg/mod/github.com/!o!n!sdigital/dp-healthcheck@v1.2.1/healthcheck/ticker.go:36 +0xee
dp-recipe-api_1                           |
dp-recipe-api_1                           | Goroutine 49 (running) created at:
dp-recipe-api_1                           |   net/http.(*Server).Serve()
dp-recipe-api_1                           |       /usr/local/go/src/net/http/server.go:2994 +0x644
dp-recipe-api_1                           |   net/http.(*Server).ListenAndServe()
dp-recipe-api_1                           |       /usr/local/go/src/net/http/server.go:2891 +0x109
dp-recipe-api_1                           |   github.com/ONSdigital/dp-net/http.glob..func1()
dp-recipe-api_1                           |       /go/.go/path/pkg/mod/github.com/!o!n!sdigital/dp-net@v1.2.0/http/server.go:150 +0x38
dp-recipe-api_1                           |   github.com/ONSdigital/dp-net/http.(*Server).listenAndServe()
dp-recipe-api_1                           |       /go/.go/path/pkg/mod/github.com/!o!n!sdigital/dp-net@v1.2.0/http/server.go:114 +0x18a
dp-recipe-api_1                           |   github.com/ONSdigital/dp-net/http.(*Server).ListenAndServe()
dp-recipe-api_1                           |       /go/.go/path/pkg/mod/github.com/!o!n!sdigital/dp-net@v1.2.0/http/server.go:83 +0x9c
dp-recipe-api_1                           |   github.com/ONSdigital/dp-recipe-api/service.(*Service).Run.func1()
dp-recipe-api_1                           |       /go/service/service.go:98 +0x5b
dp-recipe-api_1                           |
dp-recipe-api_1                           | Goroutine 31 (running) created at:
dp-recipe-api_1                           |   github.com/ONSdigital/dp-healthcheck/healthcheck.(*ticker).start()
dp-recipe-api_1                           |       /go/.go/path/pkg/mod/github.com/!o!n!sdigital/dp-healthcheck@v1.2.1/healthcheck/ticker.go:31 +0x6a
dp-recipe-api_1                           |   github.com/ONSdigital/dp-healthcheck/healthcheck.(*HealthCheck).Start()
dp-recipe-api_1                           |       /go/.go/path/pkg/mod/github.com/!o!n!sdigital/dp-healthcheck@v1.2.1/healthcheck/healthcheck.go:119 +0x1f0
dp-recipe-api_1                           |   github.com/ONSdigital/dp-recipe-api/service.(*Service).Run()
dp-recipe-api_1                           |       /go/service/service.go:94 +0xb3e
dp-recipe-api_1                           |   main.run()
dp-recipe-api_1                           |       /go/main.go:53 +0x664
dp-recipe-api_1                           |   main.main()
dp-recipe-api_1                           |       /go/main.go:29 +0x96
dp-recipe-api_1                           | ==================
```