### PR TITLE
fixed additional data race between handler and loopAppStartingUp

### DIFF
--- a/healthcheck/handler.go
+++ b/healthcheck/handler.go
@@ -13,10 +13,15 @@ var minTime = time.Unix(0, 0)
 
 // Handler responds to an http request for the current health status
 func (hc *HealthCheck) Handler(w http.ResponseWriter, req *http.Request) {
+	hc.statusLock.Lock()
+	defer hc.statusLock.Unlock()
+
+	now := time.Now().UTC()
 	ctx := req.Context()
 
 	newStatus := hc.getAppStatus(ctx)
-	hc.SetStatusAndUptime(newStatus)
+	hc.Status = newStatus
+	hc.Uptime = now.Sub(hc.StartTime) / time.Millisecond
 
 	b, err := json.Marshal(hc)
 	if err != nil {


### PR DESCRIPTION
### What

Fixed additional data race cases, between loopAppStartingUp and Handler, by increasing the scope of the code that requires the status lock to be acquired.
- Handler: the whole func needs to be locked (including getting current status, setting it and marshaling)
- loopAppStartingUp: each iteration requires to be locked (get and set status and time)
- Removed `SetStatusAndUptime`, as it was 'too narrow'
- subscription: get and set status and time.

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- (tested locally, already done) You can run a full Cantabular import + export, restart some containers in the process, and validate 

### Who can review

anyone