### PR TITLE
Fix use of time.After() to clean up timer resource.

### DIFF
--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -129,13 +129,24 @@ func (hc *HealthCheck) startTracker(ctx context.Context) {
 	hc.tickersWaitgroup.Add(1)
 	go func(ctx context.Context) {
 		defer hc.tickersWaitgroup.Done()
+		delay := time.NewTimer(hc.criticalErrorTimeout)
 		for {
 			select {
-			case <-time.After(hc.criticalErrorTimeout):
+			case <-delay.C:
 				hc.loopAppStartingUp(ctx)
 			case <-ctx.Done():
+				// Ensure timer is stopped and its resources are freed
+				if !delay.Stop() {
+					// if the timer has been stopped then read from the channel
+					<-delay.C
+				}
 				return
 			case <-hc.stopper:
+				// Ensure timer is stopped and its resources are freed
+				if !delay.Stop() {
+					// if the timer has been stopped then read from the channel
+					<-delay.C
+				}
 				return
 			}
 		}
@@ -148,8 +159,9 @@ func (hc *HealthCheck) startTracker(ctx context.Context) {
 func (hc *HealthCheck) loopAppStartingUp(ctx context.Context) {
 	intervalWithJitter := calcIntervalWithJitter(hc.interval / 10)
 	for {
+		delay := time.NewTimer(intervalWithJitter)
 		select {
-		case <-time.After(intervalWithJitter):
+		case <-delay.C:
 			hc.statusLock.Lock()
 
 			now := time.Now().UTC()
@@ -168,8 +180,18 @@ func (hc *HealthCheck) loopAppStartingUp(ctx context.Context) {
 			return
 
 		case <-ctx.Done():
+			// Ensure timer is stopped and its resources are freed
+			if !delay.Stop() {
+				// if the timer has been stopped then read from the channel
+				<-delay.C
+			}
 			return
 		case <-hc.stopper:
+			// Ensure timer is stopped and its resources are freed
+			if !delay.Stop() {
+				// if the timer has been stopped then read from the channel
+				<-delay.C
+			}
 			return
 		}
 	}

--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -129,8 +129,8 @@ func (hc *HealthCheck) startTracker(ctx context.Context) {
 	hc.tickersWaitgroup.Add(1)
 	go func(ctx context.Context) {
 		defer hc.tickersWaitgroup.Done()
-		delay := time.NewTimer(hc.criticalErrorTimeout)
 		for {
+			delay := time.NewTimer(hc.criticalErrorTimeout)
 			select {
 			case <-delay.C:
 				hc.loopAppStartingUp(ctx)


### PR DESCRIPTION
### What

time.After() usage was leaking resources according to this article:
https://www.arangodb.com/2020/09/a-story-of-a-memory-leak-in-go-how-to-properly-use-time-after/

These changes are to fix all possible instances of that issue.

### How to review

Visually check changes.
do 'make test'

### Who can review

Anyone, possibly Gedge, Joshua, Nathan