### PR TITLE
Removed nancy-ignore

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,1 +1,0 @@
-CVE-2020-26160 # No upgrade path for github.com/dgrijalva/jwt-go. See: https://ossindex.sonatype.org/vulnerability/c16fb56d-9de6-4065-9fca-d2b4cfb13020?component-type=golang&component-name=github.com%2Fdgrijalva%2Fjwt-go&utm_source=nancy-client&utm_medium=integration&utm_content=0.0.0-dev


### PR DESCRIPTION
### What

Deleted `.nancy-ignore` file as no longer needed.

### How to review

- Checkout branch, run `make audit` to confirm no vulnerabilities are found.

### Who can review

A member of the ONS.
